### PR TITLE
WIP Bots

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -678,8 +678,20 @@ pub enum FetchMode {
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
 pub enum OutputFormat {
+    /// Print output in a human-readable form.
     Human,
+    /// Print output in a machine-readable form with minimal extra context.
     Json,
+    /// Print output in a machine-readable form with as much additional context
+    /// as possible to enable another tool to operate on that information.
+    ///
+    /// Extra information will be stored in a top-level 'context' field and
+    /// include:
+    ///
+    /// * criteria: The criteria this project defines (and their descriptions)
+    /// * metadata: The output of cargo-metadata
+    /// * store: The location of the store (supply-chain dir)
+    JsonFull,
 }
 
 #[derive(Clone, Debug)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -34,6 +34,11 @@ pub struct Cli {
     #[clap(help_heading = "GLOBAL OPTIONS", global = true)]
     pub manifest_path: Option<PathBuf>,
 
+    /// Instead of running cargo-metadata, use the json file at this path
+    #[clap(long, parse(from_os_str))]
+    #[clap(help_heading = "GLOBAL OPTIONS", global = true)]
+    pub with_metadata: Option<PathBuf>,
+
     /// Don't use --all-features
     ///
     /// We default to passing --all-features to `cargo metadata`

--- a/src/format.rs
+++ b/src/format.rs
@@ -562,8 +562,8 @@ pub struct JsonReport {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct JsonReportContext {
-    pub metadata: cargo_metadata::Metadata,
-    pub store_path: String,
+    // pub metadata: cargo_metadata::Metadata,
+    // pub store_path: String,
     pub criteria: SortedMap<CriteriaName, CriteriaEntry>,
 }
 

--- a/src/format.rs
+++ b/src/format.rs
@@ -616,4 +616,5 @@ pub struct JsonSuggestItem {
     pub notable_parents: String,
     pub suggested_criteria: Vec<CriteriaName>,
     pub suggested_diff: DiffRecommendation,
+    pub confident: bool,
 }

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,5 +1,6 @@
 //! Details of the file formats used by cargo vet
 
+use crate::resolver::{DiffRecommendation, ViolationConflict};
 use crate::serialization::spanned::Spanned;
 use crate::{flock::Filesystem, serialization};
 use core::{cmp, fmt};
@@ -531,4 +532,88 @@ impl FetchCommand {
 pub struct CommandHistory {
     #[serde(flatten)]
     pub last_fetch: Option<FetchCommand>,
+}
+
+////////////////////////////////////////////////////////////////////////////////////
+//                                                                                //
+//                                                                                //
+//                                                                                //
+//                             <json report output>                               //
+//                                                                                //
+//                                                                                //
+//                                                                                //
+////////////////////////////////////////////////////////////////////////////////////
+
+/// A string of the form "package:version"
+pub type PackageAndVersion = String;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JsonPackage {
+    pub name: PackageName,
+    pub version: Version,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JsonReport {
+    pub context: Option<JsonReportContext>,
+    #[serde(flatten)]
+    pub conclusion: JsonReportConclusion,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JsonReportContext {
+    pub metadata: cargo_metadata::Metadata,
+    pub store_path: String,
+    pub criteria: SortedMap<CriteriaName, CriteriaEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "conclusion")]
+pub enum JsonReportConclusion {
+    #[serde(rename = "success")]
+    Success(JsonReportSuccess),
+    #[serde(rename = "fail (violation)")]
+    FailForViolationConflict(JsonReportFailForViolationConflict),
+    #[serde(rename = "fail (vetting)")]
+    FailForVet(JsonReportFailForVet),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JsonReportSuccess {
+    pub vetted_fully: Vec<JsonPackage>,
+    pub vetted_partially: Vec<JsonPackage>,
+    pub vetted_with_exemptions: Vec<JsonPackage>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JsonReportFailForViolationConflict {
+    pub violations: SortedMap<PackageAndVersion, Vec<ViolationConflict>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JsonReportFailForVet {
+    pub failures: Vec<JsonVetFailure>,
+    pub suggest: Option<JsonSuggest>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JsonSuggest {
+    pub suggestions: Vec<JsonSuggestItem>,
+    pub suggest_by_criteria: SortedMap<CriteriaName, Vec<JsonSuggestItem>>,
+    pub total_lines: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JsonVetFailure {
+    pub name: PackageName,
+    pub version: Version,
+    pub missing_criteria: Vec<CriteriaName>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JsonSuggestItem {
+    pub name: PackageName,
+    pub notable_parents: String,
+    pub suggested_criteria: Vec<CriteriaName>,
+    pub suggested_diff: DiffRecommendation,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1281,7 +1281,8 @@ fn cmd_suggest(
         OutputFormat::Human => report
             .print_suggest_human(out, cfg, suggest.as_ref())
             .into_diagnostic()?,
-        OutputFormat::Json => report.print_json(out, cfg, suggest.as_ref())?,
+        OutputFormat::Json => report.print_json(out, None, suggest.as_ref())?,
+        OutputFormat::JsonFull => report.print_json(out, Some(cfg), suggest.as_ref())?,
     }
 
     Ok(())
@@ -1513,7 +1514,8 @@ fn cmd_check(out: &Arc<dyn Out>, cfg: &Config, sub_args: &CheckArgs) -> Result<(
         OutputFormat::Human => report
             .print_human(out, cfg, suggest.as_ref())
             .into_diagnostic()?,
-        OutputFormat::Json => report.print_json(out, cfg, suggest.as_ref())?,
+        OutputFormat::Json => report.print_json(out, None, suggest.as_ref())?,
+        OutputFormat::JsonFull => report.print_json(out, Some(cfg), suggest.as_ref())?,
     }
 
     // Only save imports if we succeeded, to avoid any modifications on error.
@@ -1733,7 +1735,7 @@ fn cmd_dump_graph(
     let graph = resolver::DepGraph::new(&cfg.metadata, cfg.cli.filter_graph.as_ref(), None);
     match cfg.cli.output_format {
         OutputFormat::Human => graph.print_mermaid(out, sub_args).into_diagnostic()?,
-        OutputFormat::Json => {
+        OutputFormat::Json | OutputFormat::JsonFull => {
             serde_json::to_writer_pretty(&**out, &graph.nodes).into_diagnostic()?
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1515,8 +1515,8 @@ fn cmd_check(out: &Arc<dyn Out>, cfg: &Config, sub_args: &CheckArgs) -> Result<(
         },
     );
 
-    // Bare `cargo vet` shouldn't suggest in CI
-    let suggest = if !cfg.cli.locked {
+    // Bare `cargo vet` shouldn't suggest in CI (unless you want --json-full)
+    let suggest = if !cfg.cli.locked || cfg.cli.output_format == OutputFormat::JsonFull {
         report.compute_suggest(cfg, network.as_ref(), true)?
     } else {
         None

--- a/src/main.rs
+++ b/src/main.rs
@@ -310,38 +310,48 @@ fn real_main() -> Result<(), miette::Report> {
     let cli = &partial_cfg.cli;
     let cargo_path = std::env::var_os(CARGO_ENV).expect("Cargo failed to set $CARGO, how?");
 
-    let mut cmd = cargo_metadata::MetadataCommand::new();
-    cmd.cargo_path(cargo_path);
-    if let Some(manifest_path) = &cli.manifest_path {
-        cmd.manifest_path(manifest_path);
-    }
-    if !cli.no_all_features {
-        cmd.features(cargo_metadata::CargoOpt::AllFeatures);
-    }
-    if cli.no_default_features {
-        cmd.features(cargo_metadata::CargoOpt::NoDefaultFeatures);
-    }
-    if !cli.features.is_empty() {
-        cmd.features(cargo_metadata::CargoOpt::SomeFeatures(cli.features.clone()));
-    }
-    // We never want cargo-vet to update the Cargo.lock.
-    // For frozen runs we also don't want to touch the network.
-    let mut other_options = Vec::new();
-    if cli.frozen {
-        other_options.push("--frozen".to_string());
-    } else {
-        other_options.push("--locked".to_string());
-    }
-    cmd.other_options(other_options);
-
-    info!("Running: {:#?}", cmd.cargo_command());
-
-    // ERRORS: immediate fatal diagnostic
-    let metadata = {
-        let _spinner = indeterminate_spinner("Running", "`cargo metadata`");
-        cmd.exec()
+    let metadata = if let Some(with_metadata) = &cli.with_metadata {
+        let file = File::open(with_metadata)
             .into_diagnostic()
-            .wrap_err("'cargo metadata' exited unsuccessfully")?
+            .wrap_err("could not open --with-metadata path")?;
+        let reader = BufReader::new(file);
+        serde_json::from_reader(reader)
+            .into_diagnostic()
+            .wrap_err("couldn't parse --with-metadata file")?
+    } else {
+        let mut cmd = cargo_metadata::MetadataCommand::new();
+        cmd.cargo_path(cargo_path);
+        if let Some(manifest_path) = &cli.manifest_path {
+            cmd.manifest_path(manifest_path);
+        }
+        if !cli.no_all_features {
+            cmd.features(cargo_metadata::CargoOpt::AllFeatures);
+        }
+        if cli.no_default_features {
+            cmd.features(cargo_metadata::CargoOpt::NoDefaultFeatures);
+        }
+        if !cli.features.is_empty() {
+            cmd.features(cargo_metadata::CargoOpt::SomeFeatures(cli.features.clone()));
+        }
+        // We never want cargo-vet to update the Cargo.lock.
+        // For frozen runs we also don't want to touch the network.
+        let mut other_options = Vec::new();
+        if cli.frozen {
+            other_options.push("--frozen".to_string());
+        } else {
+            other_options.push("--locked".to_string());
+        }
+        cmd.other_options(other_options);
+
+        info!("Running: {:#?}", cmd.cargo_command());
+
+        // ERRORS: immediate fatal diagnostic
+        {
+            let _spinner = indeterminate_spinner("Running", "`cargo metadata`");
+            cmd.exec()
+                .into_diagnostic()
+                .wrap_err("'cargo metadata' exited unsuccessfully")?
+        }
     };
 
     // trace!("Got Metadata! {:#?}", metadata);
@@ -1282,7 +1292,9 @@ fn cmd_suggest(
             .print_suggest_human(out, cfg, suggest.as_ref())
             .into_diagnostic()?,
         OutputFormat::Json => report.print_json(out, None, suggest.as_ref())?,
-        OutputFormat::JsonFull => report.print_json(out, Some((cfg, &suggest_store.audits)), suggest.as_ref())?,
+        OutputFormat::JsonFull => {
+            report.print_json(out, Some((cfg, &suggest_store.audits)), suggest.as_ref())?
+        }
     }
 
     Ok(())
@@ -1515,7 +1527,9 @@ fn cmd_check(out: &Arc<dyn Out>, cfg: &Config, sub_args: &CheckArgs) -> Result<(
             .print_human(out, cfg, suggest.as_ref())
             .into_diagnostic()?,
         OutputFormat::Json => report.print_json(out, None, suggest.as_ref())?,
-        OutputFormat::JsonFull => report.print_json(out, Some((cfg, &store.audits)), suggest.as_ref())?,
+        OutputFormat::JsonFull => {
+            report.print_json(out, Some((cfg, &store.audits)), suggest.as_ref())?
+        }
     }
 
     // Only save imports if we succeeded, to avoid any modifications on error.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1282,7 +1282,7 @@ fn cmd_suggest(
             .print_suggest_human(out, cfg, suggest.as_ref())
             .into_diagnostic()?,
         OutputFormat::Json => report.print_json(out, None, suggest.as_ref())?,
-        OutputFormat::JsonFull => report.print_json(out, Some(cfg), suggest.as_ref())?,
+        OutputFormat::JsonFull => report.print_json(out, Some((cfg, &suggest_store.audits)), suggest.as_ref())?,
     }
 
     Ok(())
@@ -1515,7 +1515,7 @@ fn cmd_check(out: &Arc<dyn Out>, cfg: &Config, sub_args: &CheckArgs) -> Result<(
             .print_human(out, cfg, suggest.as_ref())
             .into_diagnostic()?,
         OutputFormat::Json => report.print_json(out, None, suggest.as_ref())?,
-        OutputFormat::JsonFull => report.print_json(out, Some(cfg), suggest.as_ref())?,
+        OutputFormat::JsonFull => report.print_json(out, Some((cfg, &store.audits)), suggest.as_ref())?,
     }
 
     // Only save imports if we succeeded, to avoid any modifications on error.

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -65,8 +65,7 @@ use cargo_metadata::{DependencyKind, Metadata, Node, PackageId, Version};
 use core::fmt;
 use futures_util::future::join_all;
 use miette::IntoDiagnostic;
-use serde::Serialize;
-use serde_json::json;
+use serde::{Deserialize, Serialize};
 use std::cmp::Reverse;
 use std::collections::BinaryHeap;
 use std::mem;
@@ -76,8 +75,10 @@ use tracing::{error, trace, trace_span};
 use crate::errors::{RegenerateExemptionsError, SuggestError};
 use crate::format::{
     self, AuditKind, AuditsFile, CriteriaName, CriteriaStr, Delta, DependencyCriteria, DiffStat,
-    ExemptedDependency, ImportName, PackageName, PackageStr, PolicyEntry, RemoteImport,
-    SAFE_TO_DEPLOY, SAFE_TO_RUN,
+    ExemptedDependency, ImportName, JsonPackage, JsonReport, JsonReportConclusion,
+    JsonReportContext, JsonReportFailForVet, JsonReportFailForViolationConflict, JsonReportSuccess,
+    JsonSuggest, JsonSuggestItem, JsonVetFailure, PackageName, PackageStr, PolicyEntry,
+    RemoteImport, SAFE_TO_DEPLOY, SAFE_TO_RUN,
 };
 use crate::format::{FastMap, FastSet, SortedMap, SortedSet};
 use crate::network::Network;
@@ -137,7 +138,7 @@ pub struct FailForVet {
 }
 
 #[allow(clippy::large_enum_variant)]
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ViolationConflict {
     UnauditedConflict {
         violation_source: CriteriaNamespace,
@@ -167,7 +168,7 @@ pub struct SuggestItem {
     pub notable_parents: String,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DiffRecommendation {
     pub from: Option<Version>,
     pub to: Version,
@@ -192,7 +193,7 @@ pub struct CriteriaFailureSet {
     pub all: CriteriaSet,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub enum CriteriaNamespace {
     Local,
     Foreign(ImportName),
@@ -2813,61 +2814,106 @@ impl<'a> ResolveReport<'a> {
     pub fn print_json(
         &self,
         out: &Arc<dyn Out>,
-        _cfg: &Config,
+        cfg: Option<&Config>,
         suggest: Option<&Suggest>,
     ) -> Result<(), miette::Report> {
-        let result = match &self.conclusion {
-            Conclusion::Success(success) => {
-                let json_package = |pkgidx: &PackageIdx| {
-                    let package = &self.graph.nodes[*pkgidx];
-                    json!({
-                        "name": package.name,
-                        "version": package.version,
-                    })
-                };
-                json!({
-                    "conclusion": "success",
-                    "vetted_fully": success.vetted_fully.iter().map(json_package).collect::<Vec<_>>(),
-                    "vetted_partially": success.vetted_partially.iter().map(json_package).collect::<Vec<_>>(),
-                    "vetted_with_exemptions": success.vetted_with_exemptions.iter().map(json_package).collect::<Vec<_>>(),
-                })
-            }
-            Conclusion::FailForViolationConflict(fail) => json!({
-                "conclusion": "fail (violation)",
-                "violations": fail.violations.iter().map(|(pkgidx, violations)| {
-                    let package = &self.graph.nodes[*pkgidx];
-                    let key = format!("{}:{}", package.name, package.version);
-                    (key, violations)
-                }).collect::<SortedMap<_,_>>(),
+        let result = JsonReport {
+            context: cfg.map(|cfg| JsonReportContext {
+                metadata: cfg.metadata.clone(),
+                store_path: cfg.metacfg.store_path().display().to_string(),
+                criteria: SortedMap::new(),
             }),
-            Conclusion::FailForVet(fail) => {
-                // FIXME: How to report confidence for suggested criteria?
-                let json_suggest_item = |item: &SuggestItem| {
-                    let package = &self.graph.nodes[item.package];
-                    json!({
-                        "name": package.name,
-                        "notable_parents": item.notable_parents,
-                        "suggested_criteria": self.criteria_mapper.all_criteria_names(&item.suggested_criteria).collect::<Vec<_>>(),
-                        "suggested_diff": item.suggested_diff,
+            conclusion: match &self.conclusion {
+                Conclusion::Success(success) => {
+                    let json_package = |pkgidx: &PackageIdx| {
+                        let package = &self.graph.nodes[*pkgidx];
+                        JsonPackage {
+                            name: package.name.to_owned(),
+                            version: package.version.clone(),
+                        }
+                    };
+                    JsonReportConclusion::Success(JsonReportSuccess {
+                        vetted_fully: success.vetted_fully.iter().map(json_package).collect(),
+                        vetted_partially: success
+                            .vetted_partially
+                            .iter()
+                            .map(json_package)
+                            .collect(),
+                        vetted_with_exemptions: success
+                            .vetted_with_exemptions
+                            .iter()
+                            .map(json_package)
+                            .collect(),
                     })
-                };
-                json!({
-                    "conclusion": "fail (vetting)",
-                    "failures": fail.failures.iter().map(|(&pkgidx, audit_fail)| {
-                        let package = &self.graph.nodes[pkgidx];
-                        json!({
-                            "name": package.name,
-                            "version": package.version,
-                            "missing_criteria": self.criteria_mapper.all_criteria_names(&audit_fail.criteria_failures).collect::<Vec<_>>(),
-                        })
-                    }).collect::<Vec<_>>(),
-                    "suggest": suggest.map(|suggest| json!({
-                        "suggestions": suggest.suggestions.iter().map(json_suggest_item).collect::<Vec<_>>(),
-                        "suggest_by_criteria": suggest.suggestions_by_criteria.iter().map(|(criteria, items)| (criteria, items.iter().map(json_suggest_item).collect::<Vec<_>>())).collect::<SortedMap<_,_>>(),
-                        "total_lines": suggest.total_lines,
-                    })),
-                })
-            }
+                }
+                Conclusion::FailForViolationConflict(fail) => {
+                    JsonReportConclusion::FailForViolationConflict(
+                        JsonReportFailForViolationConflict {
+                            violations: fail
+                                .violations
+                                .iter()
+                                .map(|(pkgidx, violations)| {
+                                    let package = &self.graph.nodes[*pkgidx];
+                                    let key = format!("{}:{}", package.name, package.version);
+                                    (key, violations.clone())
+                                })
+                                .collect(),
+                        },
+                    )
+                }
+                Conclusion::FailForVet(fail) => {
+                    // FIXME: How to report confidence for suggested criteria?
+                    let json_suggest_item = |item: &SuggestItem| {
+                        let package = &self.graph.nodes[item.package];
+                        JsonSuggestItem {
+                            name: package.name.to_owned(),
+                            notable_parents: item.notable_parents.to_owned(),
+                            suggested_criteria: self
+                                .criteria_mapper
+                                .all_criteria_names(&item.suggested_criteria)
+                                .map(|s| s.to_owned())
+                                .collect(),
+                            suggested_diff: item.suggested_diff.clone(),
+                        }
+                    };
+                    JsonReportConclusion::FailForVet(JsonReportFailForVet {
+                        failures: fail
+                            .failures
+                            .iter()
+                            .map(|(&pkgidx, audit_fail)| {
+                                let package = &self.graph.nodes[pkgidx];
+                                JsonVetFailure {
+                                    name: package.name.to_owned(),
+                                    version: package.version.clone(),
+                                    missing_criteria: self
+                                        .criteria_mapper
+                                        .all_criteria_names(&audit_fail.criteria_failures)
+                                        .map(|s| s.to_owned())
+                                        .collect(),
+                                }
+                            })
+                            .collect(),
+                        suggest: suggest.as_ref().map(|suggest| JsonSuggest {
+                            suggestions: suggest
+                                .suggestions
+                                .iter()
+                                .map(json_suggest_item)
+                                .collect(),
+                            suggest_by_criteria: suggest
+                                .suggestions_by_criteria
+                                .iter()
+                                .map(|(criteria, items)| {
+                                    (
+                                        criteria.to_owned(),
+                                        items.iter().map(json_suggest_item).collect::<Vec<_>>(),
+                                    )
+                                })
+                                .collect(),
+                            total_lines: suggest.total_lines,
+                        }),
+                    })
+                }
+            },
         };
 
         serde_json::to_writer_pretty(&**out, &result).into_diagnostic()?;

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -2814,14 +2814,14 @@ impl<'a> ResolveReport<'a> {
     pub fn print_json(
         &self,
         out: &Arc<dyn Out>,
-        cfg: Option<&Config>,
+        cfg: Option<(&Config, &AuditsFile)>,
         suggest: Option<&Suggest>,
     ) -> Result<(), miette::Report> {
         let result = JsonReport {
-            context: cfg.map(|cfg| JsonReportContext {
+            context: cfg.map(|(cfg, audits)| JsonReportContext {
                 metadata: cfg.metadata.clone(),
                 store_path: cfg.metacfg.store_path().display().to_string(),
-                criteria: SortedMap::new(),
+                criteria: audits.criteria.clone(),
             }),
             conclusion: match &self.conclusion {
                 Conclusion::Success(success) => {

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -2818,9 +2818,9 @@ impl<'a> ResolveReport<'a> {
         suggest: Option<&Suggest>,
     ) -> Result<(), miette::Report> {
         let result = JsonReport {
-            context: cfg.map(|(cfg, audits)| JsonReportContext {
-                metadata: cfg.metadata.clone(),
-                store_path: cfg.metacfg.store_path().display().to_string(),
+            context: cfg.map(|(_cfg, audits)| JsonReportContext {
+                // metadata: cfg.metadata.clone(),
+                // store_path: cfg.metacfg.store_path().display().to_string(),
                 criteria: audits.criteria.clone(),
             }),
             conclusion: match &self.conclusion {

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -2874,6 +2874,7 @@ impl<'a> ResolveReport<'a> {
                                 .map(|s| s.to_owned())
                                 .collect(),
                             suggested_diff: item.suggested_diff.clone(),
+                            confident: item.suggested_criteria.is_fully_confident(),
                         }
                     };
                     JsonReportConclusion::FailForVet(JsonReportFailForVet {

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1098,7 +1098,7 @@ fn get_reports(metadata: &Metadata, report: ResolveReport) -> (String, String) {
         .unwrap();
     let json_output = BasicTestOutput::new();
     report
-        .print_json(&json_output.clone().as_dyn(), &cfg, suggest.as_ref())
+        .print_json(&json_output.clone().as_dyn(), None, suggest.as_ref())
         .unwrap();
     (human_output.to_string(), json_output.to_string())
 }

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-complex-full-audited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-complex-full-audited.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [
     {

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-complex-inited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-complex-inited.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [],
   "vetted_partially": [],

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-complex-minimal-audited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-complex-minimal-audited.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [
     {

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-complex-no-unaudited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-complex-no-unaudited.json.snap
@@ -3,102 +3,39 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (vetting)",
   "failures": [
     {
+      "name": "third-core",
+      "version": "10.0.0",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
-      "name": "third-core",
-      "version": "10.0.0"
+      ]
     },
     {
+      "name": "third-core",
+      "version": "5.0.0",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
-      "name": "third-core",
-      "version": "5.0.0"
+      ]
     },
     {
-      "missing_criteria": [
-        "safe-to-deploy"
-      ],
       "name": "thirdA",
-      "version": "10.0.0"
-    },
-    {
+      "version": "10.0.0",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "thirdAB",
-      "version": "10.0.0"
+      "version": "10.0.0",
+      "missing_criteria": [
+        "safe-to-deploy"
+      ]
     }
   ],
   "suggest": {
-    "suggest_by_criteria": {
-      "safe-to-deploy": [
-        {
-          "name": "third-core",
-          "notable_parents": "firstA",
-          "suggested_criteria": [
-            "safe-to-deploy"
-          ],
-          "suggested_diff": {
-            "diffstat": {
-              "count": 25,
-              "raw": "+25"
-            },
-            "from": null,
-            "to": "5.0.0"
-          }
-        },
-        {
-          "name": "third-core",
-          "notable_parents": "firstB, thirdA, thirdAB",
-          "suggested_criteria": [
-            "safe-to-deploy"
-          ],
-          "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
-            "from": null,
-            "to": "10.0.0"
-          }
-        },
-        {
-          "name": "thirdA",
-          "notable_parents": "firstA",
-          "suggested_criteria": [
-            "safe-to-deploy"
-          ],
-          "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
-            "from": null,
-            "to": "10.0.0"
-          }
-        },
-        {
-          "name": "thirdAB",
-          "notable_parents": "firstAB",
-          "suggested_criteria": [
-            "safe-to-deploy"
-          ],
-          "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
-            "from": null,
-            "to": "10.0.0"
-          }
-        }
-      ]
-    },
     "suggestions": [
       {
         "name": "third-core",
@@ -107,12 +44,12 @@ expression: json
           "safe-to-deploy"
         ],
         "suggested_diff": {
-          "diffstat": {
-            "count": 25,
-            "raw": "+25"
-          },
           "from": null,
-          "to": "5.0.0"
+          "to": "5.0.0",
+          "diffstat": {
+            "raw": "+25",
+            "count": 25
+          }
         }
       },
       {
@@ -122,12 +59,12 @@ expression: json
           "safe-to-deploy"
         ],
         "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
           "from": null,
-          "to": "10.0.0"
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
         }
       },
       {
@@ -137,12 +74,12 @@ expression: json
           "safe-to-deploy"
         ],
         "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
           "from": null,
-          "to": "10.0.0"
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
         }
       },
       {
@@ -152,15 +89,79 @@ expression: json
           "safe-to-deploy"
         ],
         "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
           "from": null,
-          "to": "10.0.0"
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
         }
       }
     ],
+    "suggest_by_criteria": {
+      "safe-to-deploy": [
+        {
+          "name": "third-core",
+          "notable_parents": "firstA",
+          "suggested_criteria": [
+            "safe-to-deploy"
+          ],
+          "suggested_diff": {
+            "from": null,
+            "to": "5.0.0",
+            "diffstat": {
+              "raw": "+25",
+              "count": 25
+            }
+          }
+        },
+        {
+          "name": "third-core",
+          "notable_parents": "firstB, thirdA, thirdAB",
+          "suggested_criteria": [
+            "safe-to-deploy"
+          ],
+          "suggested_diff": {
+            "from": null,
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
+          }
+        },
+        {
+          "name": "thirdA",
+          "notable_parents": "firstA",
+          "suggested_criteria": [
+            "safe-to-deploy"
+          ],
+          "suggested_diff": {
+            "from": null,
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
+          }
+        },
+        {
+          "name": "thirdAB",
+          "notable_parents": "firstAB",
+          "suggested_criteria": [
+            "safe-to-deploy"
+          ],
+          "suggested_diff": {
+            "from": null,
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
+          }
+        }
+      ]
+    },
     "total_lines": 325
   }
 }

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-complex-no-unaudited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-complex-no-unaudited.json.snap
@@ -50,7 +50,8 @@ expression: json
             "raw": "+25",
             "count": 25
           }
-        }
+        },
+        "confident": true
       },
       {
         "name": "third-core",
@@ -65,7 +66,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": true
       },
       {
         "name": "thirdA",
@@ -80,7 +82,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": true
       },
       {
         "name": "thirdAB",
@@ -95,7 +98,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": true
       }
     ],
     "suggest_by_criteria": {
@@ -113,7 +117,8 @@ expression: json
               "raw": "+25",
               "count": 25
             }
-          }
+          },
+          "confident": true
         },
         {
           "name": "third-core",
@@ -128,7 +133,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": true
         },
         {
           "name": "thirdA",
@@ -143,7 +149,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": true
         },
         {
           "name": "thirdAB",
@@ -158,7 +165,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": true
         }
       ]
     },

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-cycle-full-audited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-cycle-full-audited.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [
     {

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-cycle-inited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-cycle-inited.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [],
   "vetted_partially": [],

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-cycle-minimal-audited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-cycle-minimal-audited.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [
     {

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-cycle-unaudited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-cycle-unaudited.json.snap
@@ -3,24 +3,57 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (vetting)",
   "failures": [
     {
+      "name": "dev-cycle",
+      "version": "10.0.0",
       "missing_criteria": [
         "safe-to-run"
-      ],
-      "name": "dev-cycle",
-      "version": "10.0.0"
+      ]
     },
     {
+      "name": "normal",
+      "version": "10.0.0",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
-      "name": "normal",
-      "version": "10.0.0"
+      ]
     }
   ],
   "suggest": {
+    "suggestions": [
+      {
+        "name": "dev-cycle",
+        "notable_parents": "root",
+        "suggested_criteria": [
+          "safe-to-run"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
+        }
+      },
+      {
+        "name": "normal",
+        "notable_parents": "root",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
+        }
+      }
+    ],
     "suggest_by_criteria": {
       "safe-to-deploy": [
         {
@@ -30,12 +63,12 @@ expression: json
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
             "from": null,
-            "to": "10.0.0"
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
           }
         }
       ],
@@ -47,48 +80,16 @@ expression: json
             "safe-to-run"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
             "from": null,
-            "to": "10.0.0"
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
           }
         }
       ]
     },
-    "suggestions": [
-      {
-        "name": "dev-cycle",
-        "notable_parents": "root",
-        "suggested_criteria": [
-          "safe-to-run"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
-          "from": null,
-          "to": "10.0.0"
-        }
-      },
-      {
-        "name": "normal",
-        "notable_parents": "root",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
-          "from": null,
-          "to": "10.0.0"
-        }
-      }
-    ],
     "total_lines": 200
   }
 }

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-cycle-unaudited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-cycle-unaudited.json.snap
@@ -36,7 +36,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": true
       },
       {
         "name": "normal",
@@ -51,7 +52,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": true
       }
     ],
     "suggest_by_criteria": {
@@ -69,7 +71,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": true
         }
       ],
       "safe-to-run": [
@@ -86,7 +89,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": true
         }
       ]
     },

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-dev-detection-cursed-full.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-dev-detection-cursed-full.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [
     {

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-dev-detection-cursed-minimal.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-dev-detection-cursed-minimal.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [
     {

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-dev-detection-empty-deeper.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-dev-detection-empty-deeper.json.snap
@@ -64,7 +64,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": true
       },
       {
         "name": "dev-cycle-direct",
@@ -79,7 +80,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": true
       },
       {
         "name": "normal",
@@ -94,7 +96,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": true
       },
       {
         "name": "simple-dev",
@@ -109,7 +112,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": true
       },
       {
         "name": "dev-cycle-indirect",
@@ -124,7 +128,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "simple-dev-indirect",
@@ -139,7 +144,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": false
       }
     ],
     "suggest_by_criteria": {
@@ -157,7 +163,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": true
         },
         {
           "name": "normal",
@@ -172,7 +179,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": true
         }
       ],
       "safe-to-run": [
@@ -189,7 +197,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": true
         },
         {
           "name": "simple-dev",
@@ -204,7 +213,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": true
         },
         {
           "name": "dev-cycle-indirect",
@@ -219,7 +229,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "simple-dev-indirect",
@@ -234,7 +245,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": false
         }
       ]
     },

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-dev-detection-empty-deeper.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-dev-detection-empty-deeper.json.snap
@@ -3,52 +3,145 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (vetting)",
   "failures": [
     {
-      "missing_criteria": [
-        "safe-to-deploy"
-      ],
       "name": "both",
-      "version": "10.0.0"
-    },
-    {
-      "missing_criteria": [
-        "safe-to-run"
-      ],
-      "name": "dev-cycle-direct",
-      "version": "10.0.0"
-    },
-    {
-      "missing_criteria": [
-        "safe-to-run"
-      ],
-      "name": "dev-cycle-indirect",
-      "version": "10.0.0"
-    },
-    {
+      "version": "10.0.0",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
+      "name": "dev-cycle-direct",
+      "version": "10.0.0",
+      "missing_criteria": [
+        "safe-to-run"
+      ]
+    },
+    {
+      "name": "dev-cycle-indirect",
+      "version": "10.0.0",
+      "missing_criteria": [
+        "safe-to-run"
+      ]
+    },
+    {
       "name": "normal",
-      "version": "10.0.0"
+      "version": "10.0.0",
+      "missing_criteria": [
+        "safe-to-deploy"
+      ]
     },
     {
-      "missing_criteria": [
-        "safe-to-run"
-      ],
       "name": "simple-dev",
-      "version": "10.0.0"
-    },
-    {
+      "version": "10.0.0",
       "missing_criteria": [
         "safe-to-run"
-      ],
+      ]
+    },
+    {
       "name": "simple-dev-indirect",
-      "version": "10.0.0"
+      "version": "10.0.0",
+      "missing_criteria": [
+        "safe-to-run"
+      ]
     }
   ],
   "suggest": {
+    "suggestions": [
+      {
+        "name": "both",
+        "notable_parents": "root",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
+        }
+      },
+      {
+        "name": "dev-cycle-direct",
+        "notable_parents": "root",
+        "suggested_criteria": [
+          "safe-to-run"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
+        }
+      },
+      {
+        "name": "normal",
+        "notable_parents": "root",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
+        }
+      },
+      {
+        "name": "simple-dev",
+        "notable_parents": "root",
+        "suggested_criteria": [
+          "safe-to-run"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
+        }
+      },
+      {
+        "name": "dev-cycle-indirect",
+        "notable_parents": "dev-cycle-direct",
+        "suggested_criteria": [
+          "safe-to-run"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
+        }
+      },
+      {
+        "name": "simple-dev-indirect",
+        "notable_parents": "simple-dev",
+        "suggested_criteria": [
+          "safe-to-run"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
+        }
+      }
+    ],
     "suggest_by_criteria": {
       "safe-to-deploy": [
         {
@@ -58,12 +151,12 @@ expression: json
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
             "from": null,
-            "to": "10.0.0"
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
           }
         },
         {
@@ -73,12 +166,12 @@ expression: json
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
             "from": null,
-            "to": "10.0.0"
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
           }
         }
       ],
@@ -90,12 +183,12 @@ expression: json
             "safe-to-run"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
             "from": null,
-            "to": "10.0.0"
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
           }
         },
         {
@@ -105,12 +198,12 @@ expression: json
             "safe-to-run"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
             "from": null,
-            "to": "10.0.0"
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
           }
         },
         {
@@ -120,12 +213,12 @@ expression: json
             "safe-to-run"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
             "from": null,
-            "to": "10.0.0"
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
           }
         },
         {
@@ -135,108 +228,16 @@ expression: json
             "safe-to-run"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
             "from": null,
-            "to": "10.0.0"
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
           }
         }
       ]
     },
-    "suggestions": [
-      {
-        "name": "both",
-        "notable_parents": "root",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
-          "from": null,
-          "to": "10.0.0"
-        }
-      },
-      {
-        "name": "dev-cycle-direct",
-        "notable_parents": "root",
-        "suggested_criteria": [
-          "safe-to-run"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
-          "from": null,
-          "to": "10.0.0"
-        }
-      },
-      {
-        "name": "normal",
-        "notable_parents": "root",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
-          "from": null,
-          "to": "10.0.0"
-        }
-      },
-      {
-        "name": "simple-dev",
-        "notable_parents": "root",
-        "suggested_criteria": [
-          "safe-to-run"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
-          "from": null,
-          "to": "10.0.0"
-        }
-      },
-      {
-        "name": "dev-cycle-indirect",
-        "notable_parents": "dev-cycle-direct",
-        "suggested_criteria": [
-          "safe-to-run"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
-          "from": null,
-          "to": "10.0.0"
-        }
-      },
-      {
-        "name": "simple-dev-indirect",
-        "notable_parents": "simple-dev",
-        "suggested_criteria": [
-          "safe-to-run"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
-          "from": null,
-          "to": "10.0.0"
-        }
-      }
-    ],
     "total_lines": 600
   }
 }

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-dev-detection-empty.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-dev-detection-empty.json.snap
@@ -50,7 +50,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": true
       },
       {
         "name": "dev-cycle-direct",
@@ -65,7 +66,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": true
       },
       {
         "name": "normal",
@@ -80,7 +82,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": true
       },
       {
         "name": "simple-dev",
@@ -95,7 +98,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": true
       }
     ],
     "suggest_by_criteria": {
@@ -113,7 +117,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": true
         },
         {
           "name": "normal",
@@ -128,7 +133,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": true
         }
       ],
       "safe-to-run": [
@@ -145,7 +151,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": true
         },
         {
           "name": "simple-dev",
@@ -160,7 +167,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": true
         }
       ]
     },

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-dev-detection-empty.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-dev-detection-empty.json.snap
@@ -3,38 +3,101 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (vetting)",
   "failures": [
     {
-      "missing_criteria": [
-        "safe-to-deploy"
-      ],
       "name": "both",
-      "version": "10.0.0"
-    },
-    {
-      "missing_criteria": [
-        "safe-to-run"
-      ],
-      "name": "dev-cycle-direct",
-      "version": "10.0.0"
-    },
-    {
+      "version": "10.0.0",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
-      "name": "normal",
-      "version": "10.0.0"
+      ]
     },
     {
+      "name": "dev-cycle-direct",
+      "version": "10.0.0",
       "missing_criteria": [
         "safe-to-run"
-      ],
+      ]
+    },
+    {
+      "name": "normal",
+      "version": "10.0.0",
+      "missing_criteria": [
+        "safe-to-deploy"
+      ]
+    },
+    {
       "name": "simple-dev",
-      "version": "10.0.0"
+      "version": "10.0.0",
+      "missing_criteria": [
+        "safe-to-run"
+      ]
     }
   ],
   "suggest": {
+    "suggestions": [
+      {
+        "name": "both",
+        "notable_parents": "root",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
+        }
+      },
+      {
+        "name": "dev-cycle-direct",
+        "notable_parents": "root",
+        "suggested_criteria": [
+          "safe-to-run"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
+        }
+      },
+      {
+        "name": "normal",
+        "notable_parents": "root",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
+        }
+      },
+      {
+        "name": "simple-dev",
+        "notable_parents": "root",
+        "suggested_criteria": [
+          "safe-to-run"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
+        }
+      }
+    ],
     "suggest_by_criteria": {
       "safe-to-deploy": [
         {
@@ -44,12 +107,12 @@ expression: json
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
             "from": null,
-            "to": "10.0.0"
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
           }
         },
         {
@@ -59,12 +122,12 @@ expression: json
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
             "from": null,
-            "to": "10.0.0"
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
           }
         }
       ],
@@ -76,12 +139,12 @@ expression: json
             "safe-to-run"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
             "from": null,
-            "to": "10.0.0"
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
           }
         },
         {
@@ -91,78 +154,16 @@ expression: json
             "safe-to-run"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
             "from": null,
-            "to": "10.0.0"
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
           }
         }
       ]
     },
-    "suggestions": [
-      {
-        "name": "both",
-        "notable_parents": "root",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
-          "from": null,
-          "to": "10.0.0"
-        }
-      },
-      {
-        "name": "dev-cycle-direct",
-        "notable_parents": "root",
-        "suggested_criteria": [
-          "safe-to-run"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
-          "from": null,
-          "to": "10.0.0"
-        }
-      },
-      {
-        "name": "normal",
-        "notable_parents": "root",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
-          "from": null,
-          "to": "10.0.0"
-        }
-      },
-      {
-        "name": "simple-dev",
-        "notable_parents": "root",
-        "suggested_criteria": [
-          "safe-to-run"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
-          "from": null,
-          "to": "10.0.0"
-        }
-      }
-    ],
     "total_lines": 400
   }
 }

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-dev-detection-unaudited-adds-uneeded-criteria-indirect.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-dev-detection-unaudited-adds-uneeded-criteria-indirect.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [
     {

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-dev-detection.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-dev-detection.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [
     {

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-haunted-full-audited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-haunted-full-audited.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [
     {

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-haunted-init.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-haunted-init.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [],
   "vetted_partially": [],

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-haunted-minimal-audited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-haunted-minimal-audited.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [
     {

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-haunted-no-unaudited-deeper.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-haunted-no-unaudited-deeper.json.snap
@@ -3,24 +3,57 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (vetting)",
   "failures": [
     {
+      "name": "third-dev",
+      "version": "10.0.0",
       "missing_criteria": [
         "safe-to-run"
-      ],
-      "name": "third-dev",
-      "version": "10.0.0"
+      ]
     },
     {
+      "name": "third-normal",
+      "version": "10.0.0",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
-      "name": "third-normal",
-      "version": "10.0.0"
+      ]
     }
   ],
   "suggest": {
+    "suggestions": [
+      {
+        "name": "third-dev",
+        "notable_parents": "first",
+        "suggested_criteria": [
+          "safe-to-run"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
+        }
+      },
+      {
+        "name": "third-normal",
+        "notable_parents": "first",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
+        }
+      }
+    ],
     "suggest_by_criteria": {
       "safe-to-deploy": [
         {
@@ -30,12 +63,12 @@ expression: json
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
             "from": null,
-            "to": "10.0.0"
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
           }
         }
       ],
@@ -47,48 +80,16 @@ expression: json
             "safe-to-run"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
             "from": null,
-            "to": "10.0.0"
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
           }
         }
       ]
     },
-    "suggestions": [
-      {
-        "name": "third-dev",
-        "notable_parents": "first",
-        "suggested_criteria": [
-          "safe-to-run"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
-          "from": null,
-          "to": "10.0.0"
-        }
-      },
-      {
-        "name": "third-normal",
-        "notable_parents": "first",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
-          "from": null,
-          "to": "10.0.0"
-        }
-      }
-    ],
     "total_lines": 200
   }
 }

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-haunted-no-unaudited-deeper.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-haunted-no-unaudited-deeper.json.snap
@@ -36,7 +36,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": true
       },
       {
         "name": "third-normal",
@@ -51,7 +52,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": true
       }
     ],
     "suggest_by_criteria": {
@@ -69,7 +71,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": true
         }
       ],
       "safe-to-run": [
@@ -86,7 +89,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": true
         }
       ]
     },

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-haunted-no-unaudited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-haunted-no-unaudited.json.snap
@@ -3,24 +3,57 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (vetting)",
   "failures": [
     {
+      "name": "third-dev",
+      "version": "10.0.0",
       "missing_criteria": [
         "safe-to-run"
-      ],
-      "name": "third-dev",
-      "version": "10.0.0"
+      ]
     },
     {
+      "name": "third-normal",
+      "version": "10.0.0",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
-      "name": "third-normal",
-      "version": "10.0.0"
+      ]
     }
   ],
   "suggest": {
+    "suggestions": [
+      {
+        "name": "third-dev",
+        "notable_parents": "first",
+        "suggested_criteria": [
+          "safe-to-run"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
+        }
+      },
+      {
+        "name": "third-normal",
+        "notable_parents": "first",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
+        }
+      }
+    ],
     "suggest_by_criteria": {
       "safe-to-deploy": [
         {
@@ -30,12 +63,12 @@ expression: json
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
             "from": null,
-            "to": "10.0.0"
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
           }
         }
       ],
@@ -47,48 +80,16 @@ expression: json
             "safe-to-run"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
             "from": null,
-            "to": "10.0.0"
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
           }
         }
       ]
     },
-    "suggestions": [
-      {
-        "name": "third-dev",
-        "notable_parents": "first",
-        "suggested_criteria": [
-          "safe-to-run"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
-          "from": null,
-          "to": "10.0.0"
-        }
-      },
-      {
-        "name": "third-normal",
-        "notable_parents": "first",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
-          "from": null,
-          "to": "10.0.0"
-        }
-      }
-    ],
     "total_lines": 200
   }
 }

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-haunted-no-unaudited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-haunted-no-unaudited.json.snap
@@ -36,7 +36,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": true
       },
       {
         "name": "third-normal",
@@ -51,7 +52,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": true
       }
     ],
     "suggest_by_criteria": {
@@ -69,7 +71,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": true
         }
       ],
       "safe-to-run": [
@@ -86,7 +89,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": true
         }
       ]
     },

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-no-deps.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-no-deps.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [],
   "vetted_partially": [],

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-only-first-deps.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-only-first-deps.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [],
   "vetted_partially": [],

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-audit-as-default-root-no-audit.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-audit-as-default-root-no-audit.json.snap
@@ -29,7 +29,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": true
       }
     ],
     "suggest_by_criteria": {
@@ -47,7 +48,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": true
         }
       ]
     },

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-audit-as-default-root-no-audit.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-audit-as-default-root-no-audit.json.snap
@@ -3,17 +3,35 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (vetting)",
   "failures": [
     {
+      "name": "root-package",
+      "version": "10.0.0",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
-      "name": "root-package",
-      "version": "10.0.0"
+      ]
     }
   ],
   "suggest": {
+    "suggestions": [
+      {
+        "name": "root-package",
+        "notable_parents": "",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
+        }
+      }
+    ],
     "suggest_by_criteria": {
       "safe-to-deploy": [
         {
@@ -23,33 +41,16 @@ expression: json
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
             "from": null,
-            "to": "10.0.0"
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
           }
         }
       ]
     },
-    "suggestions": [
-      {
-        "name": "root-package",
-        "notable_parents": "",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
-          "from": null,
-          "to": "10.0.0"
-        }
-      }
-    ],
     "total_lines": 100
   }
 }

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-audit-as-default-root-too-weak.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-audit-as-default-root-too-weak.json.snap
@@ -29,7 +29,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": true
       }
     ],
     "suggest_by_criteria": {
@@ -47,7 +48,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": true
         }
       ]
     },

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-audit-as-default-root-too-weak.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-audit-as-default-root-too-weak.json.snap
@@ -3,17 +3,35 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (vetting)",
   "failures": [
     {
+      "name": "root-package",
+      "version": "10.0.0",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
-      "name": "root-package",
-      "version": "10.0.0"
+      ]
     }
   ],
   "suggest": {
+    "suggestions": [
+      {
+        "name": "root-package",
+        "notable_parents": "",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
+        }
+      }
+    ],
     "suggest_by_criteria": {
       "safe-to-deploy": [
         {
@@ -23,33 +41,16 @@ expression: json
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
             "from": null,
-            "to": "10.0.0"
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
           }
         }
       ]
     },
-    "suggestions": [
-      {
-        "name": "root-package",
-        "notable_parents": "",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
-          "from": null,
-          "to": "10.0.0"
-        }
-      }
-    ],
     "total_lines": 100
   }
 }

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-audit-as-default-root.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-audit-as-default-root.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [],
   "vetted_partially": [],

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-audit-as-weaker-root.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-audit-as-weaker-root.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [],
   "vetted_partially": [],

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-delta-broken-cycle.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-delta-broken-cycle.json.snap
@@ -3,17 +3,35 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (vetting)",
   "failures": [
     {
+      "name": "third-party1",
+      "version": "10.0.0",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
-      "name": "third-party1",
-      "version": "10.0.0"
+      ]
     }
   ],
   "suggest": {
+    "suggestions": [
+      {
+        "name": "third-party1",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": "7.0.0",
+          "to": "8.0.0",
+          "diffstat": {
+            "raw": "+15",
+            "count": 15
+          }
+        }
+      }
+    ],
     "suggest_by_criteria": {
       "safe-to-deploy": [
         {
@@ -23,33 +41,16 @@ expression: json
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 15,
-              "raw": "+15"
-            },
             "from": "7.0.0",
-            "to": "8.0.0"
+            "to": "8.0.0",
+            "diffstat": {
+              "raw": "+15",
+              "count": 15
+            }
           }
         }
       ]
     },
-    "suggestions": [
-      {
-        "name": "third-party1",
-        "notable_parents": "first-party",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 15,
-            "raw": "+15"
-          },
-          "from": "7.0.0",
-          "to": "8.0.0"
-        }
-      }
-    ],
     "total_lines": 15
   }
 }

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-delta-broken-cycle.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-delta-broken-cycle.json.snap
@@ -29,7 +29,8 @@ expression: json
             "raw": "+15",
             "count": 15
           }
-        }
+        },
+        "confident": true
       }
     ],
     "suggest_by_criteria": {
@@ -47,7 +48,8 @@ expression: json
               "raw": "+15",
               "count": 15
             }
-          }
+          },
+          "confident": true
         }
       ]
     },

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-delta-broken-double-cycle.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-delta-broken-double-cycle.json.snap
@@ -29,7 +29,8 @@ expression: json
             "raw": "+9",
             "count": 9
           }
-        }
+        },
+        "confident": true
       }
     ],
     "suggest_by_criteria": {
@@ -47,7 +48,8 @@ expression: json
               "raw": "+9",
               "count": 9
             }
-          }
+          },
+          "confident": true
         }
       ]
     },

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-delta-broken-double-cycle.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-delta-broken-double-cycle.json.snap
@@ -3,17 +3,35 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (vetting)",
   "failures": [
     {
+      "name": "third-party1",
+      "version": "10.0.0",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
-      "name": "third-party1",
-      "version": "10.0.0"
+      ]
     }
   ],
   "suggest": {
+    "suggestions": [
+      {
+        "name": "third-party1",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": "4.0.0",
+          "to": "5.0.0",
+          "diffstat": {
+            "raw": "+9",
+            "count": 9
+          }
+        }
+      }
+    ],
     "suggest_by_criteria": {
       "safe-to-deploy": [
         {
@@ -23,33 +41,16 @@ expression: json
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 9,
-              "raw": "+9"
-            },
             "from": "4.0.0",
-            "to": "5.0.0"
+            "to": "5.0.0",
+            "diffstat": {
+              "raw": "+9",
+              "count": 9
+            }
           }
         }
       ]
     },
-    "suggestions": [
-      {
-        "name": "third-party1",
-        "notable_parents": "first-party",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 9,
-            "raw": "+9"
-          },
-          "from": "4.0.0",
-          "to": "5.0.0"
-        }
-      }
-    ],
     "total_lines": 9
   }
 }

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-delta-cycle.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-delta-cycle.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [
     {

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-delta-double-cycle.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-delta-double-cycle.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [
     {

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-deps-full-audited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-deps-full-audited.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [
     {

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-deps-init.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-deps-init.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [],
   "vetted_partially": [],

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-deps-minimal-audited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-deps-minimal-audited.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [
     {

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-deps-no-unaudited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-deps-no-unaudited.json.snap
@@ -64,7 +64,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": true
       },
       {
         "name": "build-proc-macro",
@@ -79,7 +80,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": true
       },
       {
         "name": "dev",
@@ -94,7 +96,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": true
       },
       {
         "name": "dev-proc-macro",
@@ -109,7 +112,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": true
       },
       {
         "name": "normal",
@@ -124,7 +128,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": true
       },
       {
         "name": "proc-macro",
@@ -139,7 +144,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": true
       }
     ],
     "suggest_by_criteria": {
@@ -157,7 +163,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": true
         },
         {
           "name": "build-proc-macro",
@@ -172,7 +179,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": true
         },
         {
           "name": "normal",
@@ -187,7 +195,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": true
         },
         {
           "name": "proc-macro",
@@ -202,7 +211,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": true
         }
       ],
       "safe-to-run": [
@@ -219,7 +229,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": true
         },
         {
           "name": "dev-proc-macro",
@@ -234,7 +245,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": true
         }
       ]
     },

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-deps-no-unaudited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-deps-no-unaudited.json.snap
@@ -3,52 +3,145 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (vetting)",
   "failures": [
     {
-      "missing_criteria": [
-        "safe-to-deploy"
-      ],
       "name": "build",
-      "version": "10.0.0"
-    },
-    {
+      "version": "10.0.0",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "build-proc-macro",
-      "version": "10.0.0"
+      "version": "10.0.0",
+      "missing_criteria": [
+        "safe-to-deploy"
+      ]
     },
     {
-      "missing_criteria": [
-        "safe-to-run"
-      ],
       "name": "dev",
-      "version": "10.0.0"
-    },
-    {
+      "version": "10.0.0",
       "missing_criteria": [
         "safe-to-run"
-      ],
+      ]
+    },
+    {
       "name": "dev-proc-macro",
-      "version": "10.0.0"
+      "version": "10.0.0",
+      "missing_criteria": [
+        "safe-to-run"
+      ]
     },
     {
-      "missing_criteria": [
-        "safe-to-deploy"
-      ],
       "name": "normal",
-      "version": "10.0.0"
-    },
-    {
+      "version": "10.0.0",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "proc-macro",
-      "version": "10.0.0"
+      "version": "10.0.0",
+      "missing_criteria": [
+        "safe-to-deploy"
+      ]
     }
   ],
   "suggest": {
+    "suggestions": [
+      {
+        "name": "build",
+        "notable_parents": "root",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
+        }
+      },
+      {
+        "name": "build-proc-macro",
+        "notable_parents": "root",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
+        }
+      },
+      {
+        "name": "dev",
+        "notable_parents": "root",
+        "suggested_criteria": [
+          "safe-to-run"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
+        }
+      },
+      {
+        "name": "dev-proc-macro",
+        "notable_parents": "root",
+        "suggested_criteria": [
+          "safe-to-run"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
+        }
+      },
+      {
+        "name": "normal",
+        "notable_parents": "root",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
+        }
+      },
+      {
+        "name": "proc-macro",
+        "notable_parents": "root",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
+        }
+      }
+    ],
     "suggest_by_criteria": {
       "safe-to-deploy": [
         {
@@ -58,12 +151,12 @@ expression: json
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
             "from": null,
-            "to": "10.0.0"
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
           }
         },
         {
@@ -73,12 +166,12 @@ expression: json
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
             "from": null,
-            "to": "10.0.0"
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
           }
         },
         {
@@ -88,12 +181,12 @@ expression: json
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
             "from": null,
-            "to": "10.0.0"
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
           }
         },
         {
@@ -103,12 +196,12 @@ expression: json
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
             "from": null,
-            "to": "10.0.0"
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
           }
         }
       ],
@@ -120,12 +213,12 @@ expression: json
             "safe-to-run"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
             "from": null,
-            "to": "10.0.0"
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
           }
         },
         {
@@ -135,108 +228,16 @@ expression: json
             "safe-to-run"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
             "from": null,
-            "to": "10.0.0"
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
           }
         }
       ]
     },
-    "suggestions": [
-      {
-        "name": "build",
-        "notable_parents": "root",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
-          "from": null,
-          "to": "10.0.0"
-        }
-      },
-      {
-        "name": "build-proc-macro",
-        "notable_parents": "root",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
-          "from": null,
-          "to": "10.0.0"
-        }
-      },
-      {
-        "name": "dev",
-        "notable_parents": "root",
-        "suggested_criteria": [
-          "safe-to-run"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
-          "from": null,
-          "to": "10.0.0"
-        }
-      },
-      {
-        "name": "dev-proc-macro",
-        "notable_parents": "root",
-        "suggested_criteria": [
-          "safe-to-run"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
-          "from": null,
-          "to": "10.0.0"
-        }
-      },
-      {
-        "name": "normal",
-        "notable_parents": "root",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
-          "from": null,
-          "to": "10.0.0"
-        }
-      },
-      {
-        "name": "proc-macro",
-        "notable_parents": "root",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
-          "from": null,
-          "to": "10.0.0"
-        }
-      }
-    ],
     "total_lines": 600
   }
 }

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-deps-unaudited-adds-uneeded-criteria.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-deps-unaudited-adds-uneeded-criteria.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [
     {

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-full-audited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-full-audited.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [
     {

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-init.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-init.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [],
   "vetted_partially": [],

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-long-cycle.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-long-cycle.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [
     {

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-no-unaudited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-no-unaudited.json.snap
@@ -36,7 +36,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": true
       },
       {
         "name": "third-party2",
@@ -51,7 +52,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": true
       }
     ],
     "suggest_by_criteria": {
@@ -69,7 +71,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": true
         },
         {
           "name": "third-party2",
@@ -84,7 +87,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": true
         }
       ]
     },

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-no-unaudited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-no-unaudited.json.snap
@@ -3,58 +3,25 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (vetting)",
   "failures": [
     {
+      "name": "third-party1",
+      "version": "10.0.0",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
-      "name": "third-party1",
-      "version": "10.0.0"
+      ]
     },
     {
+      "name": "third-party2",
+      "version": "10.0.0",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
-      "name": "third-party2",
-      "version": "10.0.0"
+      ]
     }
   ],
   "suggest": {
-    "suggest_by_criteria": {
-      "safe-to-deploy": [
-        {
-          "name": "third-party1",
-          "notable_parents": "first-party",
-          "suggested_criteria": [
-            "safe-to-deploy"
-          ],
-          "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
-            "from": null,
-            "to": "10.0.0"
-          }
-        },
-        {
-          "name": "third-party2",
-          "notable_parents": "first-party",
-          "suggested_criteria": [
-            "safe-to-deploy"
-          ],
-          "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
-            "from": null,
-            "to": "10.0.0"
-          }
-        }
-      ]
-    },
     "suggestions": [
       {
         "name": "third-party1",
@@ -63,12 +30,12 @@ expression: json
           "safe-to-deploy"
         ],
         "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
           "from": null,
-          "to": "10.0.0"
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
         }
       },
       {
@@ -78,15 +45,49 @@ expression: json
           "safe-to-deploy"
         ],
         "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
           "from": null,
-          "to": "10.0.0"
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
         }
       }
     ],
+    "suggest_by_criteria": {
+      "safe-to-deploy": [
+        {
+          "name": "third-party1",
+          "notable_parents": "first-party",
+          "suggested_criteria": [
+            "safe-to-deploy"
+          ],
+          "suggested_diff": {
+            "from": null,
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
+          }
+        },
+        {
+          "name": "third-party2",
+          "notable_parents": "first-party",
+          "suggested_criteria": [
+            "safe-to-deploy"
+          ],
+          "suggested_diff": {
+            "from": null,
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
+          }
+        }
+      ]
+    },
     "total_lines": 200
   }
 }

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-noop-delta.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-noop-delta.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [
     {

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-not-a-real-dep.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-not-a-real-dep.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [
     {

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-unaudited-extra.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-unaudited-extra.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [
     {

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-unaudited-in-delta.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-unaudited-in-delta.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [
     {

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-unaudited-in-direct-full.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-unaudited-in-direct-full.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [
     {

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-unaudited-in-full.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-unaudited-in-full.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [
     {

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-unaudited-nested-stronger-req.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-unaudited-nested-stronger-req.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [
     {

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-unaudited-nested-weaker-req-needs-dep-criteria.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-unaudited-nested-weaker-req-needs-dep-criteria.json.snap
@@ -3,17 +3,35 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (vetting)",
   "failures": [
     {
+      "name": "transitive-third-party1",
+      "version": "10.0.0",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
-      "name": "transitive-third-party1",
-      "version": "10.0.0"
+      ]
     }
   ],
   "suggest": {
+    "suggestions": [
+      {
+        "name": "transitive-third-party1",
+        "notable_parents": "third-party1",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
+        }
+      }
+    ],
     "suggest_by_criteria": {
       "safe-to-deploy": [
         {
@@ -23,33 +41,16 @@ expression: json
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
             "from": null,
-            "to": "10.0.0"
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
           }
         }
       ]
     },
-    "suggestions": [
-      {
-        "name": "transitive-third-party1",
-        "notable_parents": "third-party1",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
-          "from": null,
-          "to": "10.0.0"
-        }
-      }
-    ],
     "total_lines": 100
   }
 }

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-unaudited-nested-weaker-req-needs-dep-criteria.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-unaudited-nested-weaker-req-needs-dep-criteria.json.snap
@@ -29,7 +29,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": true
       }
     ],
     "suggest_by_criteria": {
@@ -47,7 +48,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": true
         }
       ]
     },

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-unaudited-nested-weaker-req.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-unaudited-nested-weaker-req.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [
     {

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-unaudited-overbroad.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-unaudited-overbroad.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [
     {

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-unaudited-partial-twins.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-unaudited-partial-twins.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [
     {

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-unaudited-twins.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-unaudited-twins.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [
     {

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-useless-long-cycle.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-useless-long-cycle.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [
     {

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin_simple_foreign_audited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin_simple_foreign_audited.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [
     {

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin_simple_foreign_dep_criteria_fail.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin_simple_foreign_dep_criteria_fail.json.snap
@@ -29,7 +29,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": true
       }
     ],
     "suggest_by_criteria": {
@@ -47,7 +48,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": true
         }
       ]
     },

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin_simple_foreign_dep_criteria_fail.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin_simple_foreign_dep_criteria_fail.json.snap
@@ -3,17 +3,35 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (vetting)",
   "failures": [
     {
+      "name": "transitive-third-party1",
+      "version": "10.0.0",
       "missing_criteria": [
         "peer-company::reviewed"
-      ],
-      "name": "transitive-third-party1",
-      "version": "10.0.0"
+      ]
     }
   ],
   "suggest": {
+    "suggestions": [
+      {
+        "name": "transitive-third-party1",
+        "notable_parents": "third-party1",
+        "suggested_criteria": [
+          "peer-company::reviewed"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
+        }
+      }
+    ],
     "suggest_by_criteria": {
       "peer-company::reviewed": [
         {
@@ -23,33 +41,16 @@ expression: json
             "peer-company::reviewed"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
             "from": null,
-            "to": "10.0.0"
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
           }
         }
       ]
     },
-    "suggestions": [
-      {
-        "name": "transitive-third-party1",
-        "notable_parents": "third-party1",
-        "suggested_criteria": [
-          "peer-company::reviewed"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
-          "from": null,
-          "to": "10.0.0"
-        }
-      }
-    ],
     "total_lines": 100
   }
 }

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin_simple_foreign_dep_criteria_pass.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin_simple_foreign_dep_criteria_pass.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [
     {

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin_simple_foreign_tag_team.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin_simple_foreign_tag_team.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [
     {

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin_simple_mega_foreign_tag_team.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin_simple_mega_foreign_tag_team.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [
     {

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-core10-partially-too-weak-via-strong-delta.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-core10-partially-too-weak-via-strong-delta.json.snap
@@ -29,7 +29,8 @@ expression: json
             "raw": "+25",
             "count": 25
           }
-        }
+        },
+        "confident": true
       }
     ],
     "suggest_by_criteria": {
@@ -47,7 +48,8 @@ expression: json
               "raw": "+25",
               "count": 25
             }
-          }
+          },
+          "confident": true
         }
       ]
     },

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-core10-partially-too-weak-via-strong-delta.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-core10-partially-too-weak-via-strong-delta.json.snap
@@ -3,17 +3,35 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (vetting)",
   "failures": [
     {
+      "name": "third-core",
+      "version": "10.0.0",
       "missing_criteria": [
         "reviewed"
-      ],
-      "name": "third-core",
-      "version": "10.0.0"
+      ]
     }
   ],
   "suggest": {
+    "suggestions": [
+      {
+        "name": "third-core",
+        "notable_parents": "firstB, thirdA, thirdAB",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "5.0.0",
+          "diffstat": {
+            "raw": "+25",
+            "count": 25
+          }
+        }
+      }
+    ],
     "suggest_by_criteria": {
       "reviewed": [
         {
@@ -23,33 +41,16 @@ expression: json
             "reviewed"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 25,
-              "raw": "+25"
-            },
             "from": null,
-            "to": "5.0.0"
+            "to": "5.0.0",
+            "diffstat": {
+              "raw": "+25",
+              "count": 25
+            }
           }
         }
       ]
     },
-    "suggestions": [
-      {
-        "name": "third-core",
-        "notable_parents": "firstB, thirdA, thirdAB",
-        "suggested_criteria": [
-          "reviewed"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 25,
-            "raw": "+25"
-          },
-          "from": null,
-          "to": "5.0.0"
-        }
-      }
-    ],
     "total_lines": 25
   }
 }

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-core10-partially-too-weak-via-weak-delta.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-core10-partially-too-weak-via-weak-delta.json.snap
@@ -29,7 +29,8 @@ expression: json
             "raw": "+75",
             "count": 75
           }
-        }
+        },
+        "confident": true
       }
     ],
     "suggest_by_criteria": {
@@ -47,7 +48,8 @@ expression: json
               "raw": "+75",
               "count": 75
             }
-          }
+          },
+          "confident": true
         }
       ]
     },

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-core10-partially-too-weak-via-weak-delta.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-core10-partially-too-weak-via-weak-delta.json.snap
@@ -3,17 +3,35 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (vetting)",
   "failures": [
     {
+      "name": "third-core",
+      "version": "10.0.0",
       "missing_criteria": [
         "reviewed"
-      ],
-      "name": "third-core",
-      "version": "10.0.0"
+      ]
     }
   ],
   "suggest": {
+    "suggestions": [
+      {
+        "name": "third-core",
+        "notable_parents": "firstB, thirdA, thirdAB",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "from": "5.0.0",
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+75",
+            "count": 75
+          }
+        }
+      }
+    ],
     "suggest_by_criteria": {
       "reviewed": [
         {
@@ -23,33 +41,16 @@ expression: json
             "reviewed"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 75,
-              "raw": "+75"
-            },
             "from": "5.0.0",
-            "to": "10.0.0"
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+75",
+              "count": 75
+            }
           }
         }
       ]
     },
-    "suggestions": [
-      {
-        "name": "third-core",
-        "notable_parents": "firstB, thirdA, thirdAB",
-        "suggested_criteria": [
-          "reviewed"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 75,
-            "raw": "+75"
-          },
-          "from": "5.0.0",
-          "to": "10.0.0"
-        }
-      }
-    ],
     "total_lines": 75
   }
 }

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-core10-partially-too-weak.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-core10-partially-too-weak.json.snap
@@ -29,7 +29,8 @@ expression: json
             "raw": "+75",
             "count": 75
           }
-        }
+        },
+        "confident": true
       }
     ],
     "suggest_by_criteria": {
@@ -47,7 +48,8 @@ expression: json
               "raw": "+75",
               "count": 75
             }
-          }
+          },
+          "confident": true
         }
       ]
     },

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-core10-partially-too-weak.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-core10-partially-too-weak.json.snap
@@ -3,17 +3,35 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (vetting)",
   "failures": [
     {
+      "name": "third-core",
+      "version": "10.0.0",
       "missing_criteria": [
         "reviewed"
-      ],
-      "name": "third-core",
-      "version": "10.0.0"
+      ]
     }
   ],
   "suggest": {
+    "suggestions": [
+      {
+        "name": "third-core",
+        "notable_parents": "firstB, thirdA, thirdAB",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "from": "5.0.0",
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+75",
+            "count": 75
+          }
+        }
+      }
+    ],
     "suggest_by_criteria": {
       "reviewed": [
         {
@@ -23,33 +41,16 @@ expression: json
             "reviewed"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 75,
-              "raw": "+75"
-            },
             "from": "5.0.0",
-            "to": "10.0.0"
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+75",
+              "count": 75
+            }
           }
         }
       ]
     },
-    "suggestions": [
-      {
-        "name": "third-core",
-        "notable_parents": "firstB, thirdA, thirdAB",
-        "suggested_criteria": [
-          "reviewed"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 75,
-            "raw": "+75"
-          },
-          "from": "5.0.0",
-          "to": "10.0.0"
-        }
-      }
-    ],
     "total_lines": 75
   }
 }

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-core10-too-weak.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-core10-too-weak.json.snap
@@ -29,7 +29,8 @@ expression: json
             "raw": "+75",
             "count": 75
           }
-        }
+        },
+        "confident": true
       }
     ],
     "suggest_by_criteria": {
@@ -47,7 +48,8 @@ expression: json
               "raw": "+75",
               "count": 75
             }
-          }
+          },
+          "confident": true
         }
       ]
     },

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-core10-too-weak.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-core10-too-weak.json.snap
@@ -3,17 +3,35 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (vetting)",
   "failures": [
     {
+      "name": "third-core",
+      "version": "10.0.0",
       "missing_criteria": [
         "reviewed"
-      ],
-      "name": "third-core",
-      "version": "10.0.0"
+      ]
     }
   ],
   "suggest": {
+    "suggestions": [
+      {
+        "name": "third-core",
+        "notable_parents": "firstB, thirdA, thirdAB",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "from": "5.0.0",
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+75",
+            "count": 75
+          }
+        }
+      }
+    ],
     "suggest_by_criteria": {
       "reviewed": [
         {
@@ -23,33 +41,16 @@ expression: json
             "reviewed"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 75,
-              "raw": "+75"
-            },
             "from": "5.0.0",
-            "to": "10.0.0"
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+75",
+              "count": 75
+            }
           }
         }
       ]
     },
-    "suggestions": [
-      {
-        "name": "third-core",
-        "notable_parents": "firstB, thirdA, thirdAB",
-        "suggested_criteria": [
-          "reviewed"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 75,
-            "raw": "+75"
-          },
-          "from": "5.0.0",
-          "to": "10.0.0"
-        }
-      }
-    ],
     "total_lines": 75
   }
 }

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-full-audited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-full-audited.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [
     {

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-inited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-inited.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [],
   "vetted_partially": [],

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-missing-core10.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-missing-core10.json.snap
@@ -29,7 +29,8 @@ expression: json
             "raw": "+75",
             "count": 75
           }
-        }
+        },
+        "confident": true
       }
     ],
     "suggest_by_criteria": {
@@ -47,7 +48,8 @@ expression: json
               "raw": "+75",
               "count": 75
             }
-          }
+          },
+          "confident": true
         }
       ]
     },

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-missing-core10.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-missing-core10.json.snap
@@ -3,17 +3,35 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (vetting)",
   "failures": [
     {
+      "name": "third-core",
+      "version": "10.0.0",
       "missing_criteria": [
         "reviewed"
-      ],
-      "name": "third-core",
-      "version": "10.0.0"
+      ]
     }
   ],
   "suggest": {
+    "suggestions": [
+      {
+        "name": "third-core",
+        "notable_parents": "firstB, thirdA, thirdAB",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "from": "5.0.0",
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+75",
+            "count": 75
+          }
+        }
+      }
+    ],
     "suggest_by_criteria": {
       "reviewed": [
         {
@@ -23,33 +41,16 @@ expression: json
             "reviewed"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 75,
-              "raw": "+75"
-            },
             "from": "5.0.0",
-            "to": "10.0.0"
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+75",
+              "count": 75
+            }
           }
         }
       ]
     },
-    "suggestions": [
-      {
-        "name": "third-core",
-        "notable_parents": "firstB, thirdA, thirdAB",
-        "suggested_criteria": [
-          "reviewed"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 75,
-            "raw": "+75"
-          },
-          "from": "5.0.0",
-          "to": "10.0.0"
-        }
-      }
-    ],
     "total_lines": 75
   }
 }

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-missing-core5.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-missing-core5.json.snap
@@ -29,7 +29,8 @@ expression: json
             "raw": "+25",
             "count": 25
           }
-        }
+        },
+        "confident": true
       }
     ],
     "suggest_by_criteria": {
@@ -47,7 +48,8 @@ expression: json
               "raw": "+25",
               "count": 25
             }
-          }
+          },
+          "confident": true
         }
       ]
     },

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-missing-core5.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-missing-core5.json.snap
@@ -3,17 +3,35 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (vetting)",
   "failures": [
     {
+      "name": "third-core",
+      "version": "5.0.0",
       "missing_criteria": [
         "reviewed"
-      ],
-      "name": "third-core",
-      "version": "5.0.0"
+      ]
     }
   ],
   "suggest": {
+    "suggestions": [
+      {
+        "name": "third-core",
+        "notable_parents": "firstA",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "5.0.0",
+          "diffstat": {
+            "raw": "+25",
+            "count": 25
+          }
+        }
+      }
+    ],
     "suggest_by_criteria": {
       "reviewed": [
         {
@@ -23,33 +41,16 @@ expression: json
             "reviewed"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 25,
-              "raw": "+25"
-            },
             "from": null,
-            "to": "5.0.0"
+            "to": "5.0.0",
+            "diffstat": {
+              "raw": "+25",
+              "count": 25
+            }
           }
         }
       ]
     },
-    "suggestions": [
-      {
-        "name": "third-core",
-        "notable_parents": "firstA",
-        "suggested_criteria": [
-          "reviewed"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 25,
-            "raw": "+25"
-          },
-          "from": null,
-          "to": "5.0.0"
-        }
-      }
-    ],
     "total_lines": 25
   }
 }

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-no-unaudited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-no-unaudited.json.snap
@@ -3,102 +3,39 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (vetting)",
   "failures": [
     {
+      "name": "third-core",
+      "version": "10.0.0",
       "missing_criteria": [
         "reviewed"
-      ],
-      "name": "third-core",
-      "version": "10.0.0"
+      ]
     },
     {
+      "name": "third-core",
+      "version": "5.0.0",
       "missing_criteria": [
         "reviewed"
-      ],
-      "name": "third-core",
-      "version": "5.0.0"
+      ]
     },
     {
-      "missing_criteria": [
-        "reviewed"
-      ],
       "name": "thirdA",
-      "version": "10.0.0"
-    },
-    {
+      "version": "10.0.0",
       "missing_criteria": [
         "reviewed"
-      ],
+      ]
+    },
+    {
       "name": "thirdAB",
-      "version": "10.0.0"
+      "version": "10.0.0",
+      "missing_criteria": [
+        "reviewed"
+      ]
     }
   ],
   "suggest": {
-    "suggest_by_criteria": {
-      "reviewed": [
-        {
-          "name": "third-core",
-          "notable_parents": "firstA",
-          "suggested_criteria": [
-            "reviewed"
-          ],
-          "suggested_diff": {
-            "diffstat": {
-              "count": 25,
-              "raw": "+25"
-            },
-            "from": null,
-            "to": "5.0.0"
-          }
-        },
-        {
-          "name": "third-core",
-          "notable_parents": "firstB, thirdA, thirdAB",
-          "suggested_criteria": [
-            "reviewed"
-          ],
-          "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
-            "from": null,
-            "to": "10.0.0"
-          }
-        },
-        {
-          "name": "thirdA",
-          "notable_parents": "firstA",
-          "suggested_criteria": [
-            "reviewed"
-          ],
-          "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
-            "from": null,
-            "to": "10.0.0"
-          }
-        },
-        {
-          "name": "thirdAB",
-          "notable_parents": "firstAB",
-          "suggested_criteria": [
-            "reviewed"
-          ],
-          "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
-            "from": null,
-            "to": "10.0.0"
-          }
-        }
-      ]
-    },
     "suggestions": [
       {
         "name": "third-core",
@@ -107,12 +44,12 @@ expression: json
           "reviewed"
         ],
         "suggested_diff": {
-          "diffstat": {
-            "count": 25,
-            "raw": "+25"
-          },
           "from": null,
-          "to": "5.0.0"
+          "to": "5.0.0",
+          "diffstat": {
+            "raw": "+25",
+            "count": 25
+          }
         }
       },
       {
@@ -122,12 +59,12 @@ expression: json
           "reviewed"
         ],
         "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
           "from": null,
-          "to": "10.0.0"
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
         }
       },
       {
@@ -137,12 +74,12 @@ expression: json
           "reviewed"
         ],
         "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
           "from": null,
-          "to": "10.0.0"
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
         }
       },
       {
@@ -152,15 +89,79 @@ expression: json
           "reviewed"
         ],
         "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
           "from": null,
-          "to": "10.0.0"
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
         }
       }
     ],
+    "suggest_by_criteria": {
+      "reviewed": [
+        {
+          "name": "third-core",
+          "notable_parents": "firstA",
+          "suggested_criteria": [
+            "reviewed"
+          ],
+          "suggested_diff": {
+            "from": null,
+            "to": "5.0.0",
+            "diffstat": {
+              "raw": "+25",
+              "count": 25
+            }
+          }
+        },
+        {
+          "name": "third-core",
+          "notable_parents": "firstB, thirdA, thirdAB",
+          "suggested_criteria": [
+            "reviewed"
+          ],
+          "suggested_diff": {
+            "from": null,
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
+          }
+        },
+        {
+          "name": "thirdA",
+          "notable_parents": "firstA",
+          "suggested_criteria": [
+            "reviewed"
+          ],
+          "suggested_diff": {
+            "from": null,
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
+          }
+        },
+        {
+          "name": "thirdAB",
+          "notable_parents": "firstAB",
+          "suggested_criteria": [
+            "reviewed"
+          ],
+          "suggested_diff": {
+            "from": null,
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
+          }
+        }
+      ]
+    },
     "total_lines": 325
   }
 }

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-no-unaudited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-no-unaudited.json.snap
@@ -50,7 +50,8 @@ expression: json
             "raw": "+25",
             "count": 25
           }
-        }
+        },
+        "confident": true
       },
       {
         "name": "third-core",
@@ -65,7 +66,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": true
       },
       {
         "name": "thirdA",
@@ -80,7 +82,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": true
       },
       {
         "name": "thirdAB",
@@ -95,7 +98,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": true
       }
     ],
     "suggest_by_criteria": {
@@ -113,7 +117,8 @@ expression: json
               "raw": "+25",
               "count": 25
             }
-          }
+          },
+          "confident": true
         },
         {
           "name": "third-core",
@@ -128,7 +133,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": true
         },
         {
           "name": "thirdA",
@@ -143,7 +149,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": true
         },
         {
           "name": "thirdAB",
@@ -158,7 +165,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": true
         }
       ]
     },

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-full-audit-overshoot.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-full-audit-overshoot.json.snap
@@ -3,17 +3,35 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (vetting)",
   "failures": [
     {
+      "name": "third-party1",
+      "version": "10.0.0",
       "missing_criteria": [
         "reviewed"
-      ],
-      "name": "third-party1",
-      "version": "10.0.0"
+      ]
     }
   ],
   "suggest": {
+    "suggestions": [
+      {
+        "name": "third-party1",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "from": "5.0.0",
+          "to": "4.0.0",
+          "diffstat": {
+            "raw": "-9",
+            "count": 9
+          }
+        }
+      }
+    ],
     "suggest_by_criteria": {
       "reviewed": [
         {
@@ -23,33 +41,16 @@ expression: json
             "reviewed"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 9,
-              "raw": "-9"
-            },
             "from": "5.0.0",
-            "to": "4.0.0"
+            "to": "4.0.0",
+            "diffstat": {
+              "raw": "-9",
+              "count": 9
+            }
           }
         }
       ]
     },
-    "suggestions": [
-      {
-        "name": "third-party1",
-        "notable_parents": "first-party",
-        "suggested_criteria": [
-          "reviewed"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 9,
-            "raw": "-9"
-          },
-          "from": "5.0.0",
-          "to": "4.0.0"
-        }
-      }
-    ],
     "total_lines": 9
   }
 }

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-full-audit-overshoot.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-full-audit-overshoot.json.snap
@@ -29,7 +29,8 @@ expression: json
             "raw": "-9",
             "count": 9
           }
-        }
+        },
+        "confident": true
       }
     ],
     "suggest_by_criteria": {
@@ -47,7 +48,8 @@ expression: json
               "raw": "-9",
               "count": 9
             }
-          }
+          },
+          "confident": true
         }
       ]
     },

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-full-audit-too-weak.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-full-audit-too-weak.json.snap
@@ -29,7 +29,8 @@ expression: json
             "raw": "+75",
             "count": 75
           }
-        }
+        },
+        "confident": true
       }
     ],
     "suggest_by_criteria": {
@@ -47,7 +48,8 @@ expression: json
               "raw": "+75",
               "count": 75
             }
-          }
+          },
+          "confident": true
         }
       ]
     },

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-full-audit-too-weak.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-full-audit-too-weak.json.snap
@@ -3,17 +3,35 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (vetting)",
   "failures": [
     {
+      "name": "third-party1",
+      "version": "10.0.0",
       "missing_criteria": [
         "reviewed"
-      ],
-      "name": "third-party1",
-      "version": "10.0.0"
+      ]
     }
   ],
   "suggest": {
+    "suggestions": [
+      {
+        "name": "third-party1",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "from": "5.0.0",
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+75",
+            "count": 75
+          }
+        }
+      }
+    ],
     "suggest_by_criteria": {
       "reviewed": [
         {
@@ -23,33 +41,16 @@ expression: json
             "reviewed"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 75,
-              "raw": "+75"
-            },
             "from": "5.0.0",
-            "to": "10.0.0"
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+75",
+              "count": 75
+            }
           }
         }
       ]
     },
-    "suggestions": [
-      {
-        "name": "third-party1",
-        "notable_parents": "first-party",
-        "suggested_criteria": [
-          "reviewed"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 75,
-            "raw": "+75"
-          },
-          "from": "5.0.0",
-          "to": "10.0.0"
-        }
-      }
-    ],
     "total_lines": 75
   }
 }

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-full-audit-undershoot.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-full-audit-undershoot.json.snap
@@ -29,7 +29,8 @@ expression: json
             "raw": "+24",
             "count": 24
           }
-        }
+        },
+        "confident": true
       }
     ],
     "suggest_by_criteria": {
@@ -47,7 +48,8 @@ expression: json
               "raw": "+24",
               "count": 24
             }
-          }
+          },
+          "confident": true
         }
       ]
     },

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-full-audit-undershoot.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-full-audit-undershoot.json.snap
@@ -3,17 +3,35 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (vetting)",
   "failures": [
     {
+      "name": "third-party1",
+      "version": "10.0.0",
       "missing_criteria": [
         "reviewed"
-      ],
-      "name": "third-party1",
-      "version": "10.0.0"
+      ]
     }
   ],
   "suggest": {
+    "suggestions": [
+      {
+        "name": "third-party1",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "from": "5.0.0",
+          "to": "7.0.0",
+          "diffstat": {
+            "raw": "+24",
+            "count": 24
+          }
+        }
+      }
+    ],
     "suggest_by_criteria": {
       "reviewed": [
         {
@@ -23,33 +41,16 @@ expression: json
             "reviewed"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 24,
-              "raw": "+24"
-            },
             "from": "5.0.0",
-            "to": "7.0.0"
+            "to": "7.0.0",
+            "diffstat": {
+              "raw": "+24",
+              "count": 24
+            }
           }
         }
       ]
     },
-    "suggestions": [
-      {
-        "name": "third-party1",
-        "notable_parents": "first-party",
-        "suggested_criteria": [
-          "reviewed"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 24,
-            "raw": "+24"
-          },
-          "from": "5.0.0",
-          "to": "7.0.0"
-        }
-      }
-    ],
     "total_lines": 24
   }
 }

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-full-audit.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-full-audit.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [
     {

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-too-weak-full-audit.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-too-weak-full-audit.json.snap
@@ -29,7 +29,8 @@ expression: json
             "raw": "+25",
             "count": 25
           }
-        }
+        },
+        "confident": true
       }
     ],
     "suggest_by_criteria": {
@@ -47,7 +48,8 @@ expression: json
               "raw": "+25",
               "count": 25
             }
-          }
+          },
+          "confident": true
         }
       ]
     },

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-too-weak-full-audit.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-too-weak-full-audit.json.snap
@@ -3,17 +3,35 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (vetting)",
   "failures": [
     {
+      "name": "third-party1",
+      "version": "10.0.0",
       "missing_criteria": [
         "reviewed"
-      ],
-      "name": "third-party1",
-      "version": "10.0.0"
+      ]
     }
   ],
   "suggest": {
+    "suggestions": [
+      {
+        "name": "third-party1",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "5.0.0",
+          "diffstat": {
+            "raw": "+25",
+            "count": 25
+          }
+        }
+      }
+    ],
     "suggest_by_criteria": {
       "reviewed": [
         {
@@ -23,33 +41,16 @@ expression: json
             "reviewed"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 25,
-              "raw": "+25"
-            },
             "from": null,
-            "to": "5.0.0"
+            "to": "5.0.0",
+            "diffstat": {
+              "raw": "+25",
+              "count": 25
+            }
           }
         }
       ]
     },
-    "suggestions": [
-      {
-        "name": "third-party1",
-        "notable_parents": "first-party",
-        "suggested_criteria": [
-          "reviewed"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 25,
-            "raw": "+25"
-          },
-          "from": null,
-          "to": "5.0.0"
-        }
-      }
-    ],
     "total_lines": 25
   }
 }

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-unaudited-overshoot.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-unaudited-overshoot.json.snap
@@ -3,17 +3,35 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (vetting)",
   "failures": [
     {
+      "name": "third-party1",
+      "version": "10.0.0",
       "missing_criteria": [
         "reviewed"
-      ],
-      "name": "third-party1",
-      "version": "10.0.0"
+      ]
     }
   ],
   "suggest": {
+    "suggestions": [
+      {
+        "name": "third-party1",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "from": "5.0.0",
+          "to": "4.0.0",
+          "diffstat": {
+            "raw": "-9",
+            "count": 9
+          }
+        }
+      }
+    ],
     "suggest_by_criteria": {
       "reviewed": [
         {
@@ -23,33 +41,16 @@ expression: json
             "reviewed"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 9,
-              "raw": "-9"
-            },
             "from": "5.0.0",
-            "to": "4.0.0"
+            "to": "4.0.0",
+            "diffstat": {
+              "raw": "-9",
+              "count": 9
+            }
           }
         }
       ]
     },
-    "suggestions": [
-      {
-        "name": "third-party1",
-        "notable_parents": "first-party",
-        "suggested_criteria": [
-          "reviewed"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 9,
-            "raw": "-9"
-          },
-          "from": "5.0.0",
-          "to": "4.0.0"
-        }
-      }
-    ],
     "total_lines": 9
   }
 }

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-unaudited-overshoot.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-unaudited-overshoot.json.snap
@@ -29,7 +29,8 @@ expression: json
             "raw": "-9",
             "count": 9
           }
-        }
+        },
+        "confident": true
       }
     ],
     "suggest_by_criteria": {
@@ -47,7 +48,8 @@ expression: json
               "raw": "-9",
               "count": 9
             }
-          }
+          },
+          "confident": true
         }
       ]
     },

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-unaudited-too-weak.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-unaudited-too-weak.json.snap
@@ -29,7 +29,8 @@ expression: json
             "raw": "+75",
             "count": 75
           }
-        }
+        },
+        "confident": true
       }
     ],
     "suggest_by_criteria": {
@@ -47,7 +48,8 @@ expression: json
               "raw": "+75",
               "count": 75
             }
-          }
+          },
+          "confident": true
         }
       ]
     },

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-unaudited-too-weak.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-unaudited-too-weak.json.snap
@@ -3,17 +3,35 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (vetting)",
   "failures": [
     {
+      "name": "third-party1",
+      "version": "10.0.0",
       "missing_criteria": [
         "reviewed"
-      ],
-      "name": "third-party1",
-      "version": "10.0.0"
+      ]
     }
   ],
   "suggest": {
+    "suggestions": [
+      {
+        "name": "third-party1",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "from": "5.0.0",
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+75",
+            "count": 75
+          }
+        }
+      }
+    ],
     "suggest_by_criteria": {
       "reviewed": [
         {
@@ -23,33 +41,16 @@ expression: json
             "reviewed"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 75,
-              "raw": "+75"
-            },
             "from": "5.0.0",
-            "to": "10.0.0"
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+75",
+              "count": 75
+            }
           }
         }
       ]
     },
-    "suggestions": [
-      {
-        "name": "third-party1",
-        "notable_parents": "first-party",
-        "suggested_criteria": [
-          "reviewed"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 75,
-            "raw": "+75"
-          },
-          "from": "5.0.0",
-          "to": "10.0.0"
-        }
-      }
-    ],
     "total_lines": 75
   }
 }

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-unaudited-undershoot.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-unaudited-undershoot.json.snap
@@ -29,7 +29,8 @@ expression: json
             "raw": "+24",
             "count": 24
           }
-        }
+        },
+        "confident": true
       }
     ],
     "suggest_by_criteria": {
@@ -47,7 +48,8 @@ expression: json
               "raw": "+24",
               "count": 24
             }
-          }
+          },
+          "confident": true
         }
       ]
     },

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-unaudited-undershoot.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-unaudited-undershoot.json.snap
@@ -3,17 +3,35 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (vetting)",
   "failures": [
     {
+      "name": "third-party1",
+      "version": "10.0.0",
       "missing_criteria": [
         "reviewed"
-      ],
-      "name": "third-party1",
-      "version": "10.0.0"
+      ]
     }
   ],
   "suggest": {
+    "suggestions": [
+      {
+        "name": "third-party1",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "from": "5.0.0",
+          "to": "7.0.0",
+          "diffstat": {
+            "raw": "+24",
+            "count": 24
+          }
+        }
+      }
+    ],
     "suggest_by_criteria": {
       "reviewed": [
         {
@@ -23,33 +41,16 @@ expression: json
             "reviewed"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 24,
-              "raw": "+24"
-            },
             "from": "5.0.0",
-            "to": "7.0.0"
+            "to": "7.0.0",
+            "diffstat": {
+              "raw": "+24",
+              "count": 24
+            }
           }
         }
       ]
     },
-    "suggestions": [
-      {
-        "name": "third-party1",
-        "notable_parents": "first-party",
-        "suggested_criteria": [
-          "reviewed"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 24,
-            "raw": "+24"
-          },
-          "from": "5.0.0",
-          "to": "7.0.0"
-        }
-      }
-    ],
     "total_lines": 24
   }
 }

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-unaudited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-unaudited.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [
     {

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-full-audited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-full-audited.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [
     {

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-higher-and-lower-version-review.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-higher-and-lower-version-review.json.snap
@@ -3,17 +3,35 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (vetting)",
   "failures": [
     {
+      "name": "third-party1",
+      "version": "10.0.0",
       "missing_criteria": [
         "reviewed"
-      ],
-      "name": "third-party1",
-      "version": "10.0.0"
+      ]
     }
   ],
   "suggest": {
+    "suggestions": [
+      {
+        "name": "third-party1",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "from": "9.0.0",
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+19",
+            "count": 19
+          }
+        }
+      }
+    ],
     "suggest_by_criteria": {
       "reviewed": [
         {
@@ -23,33 +41,16 @@ expression: json
             "reviewed"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 19,
-              "raw": "+19"
-            },
             "from": "9.0.0",
-            "to": "10.0.0"
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+19",
+              "count": 19
+            }
           }
         }
       ]
     },
-    "suggestions": [
-      {
-        "name": "third-party1",
-        "notable_parents": "first-party",
-        "suggested_criteria": [
-          "reviewed"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 19,
-            "raw": "+19"
-          },
-          "from": "9.0.0",
-          "to": "10.0.0"
-        }
-      }
-    ],
     "total_lines": 19
   }
 }

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-higher-and-lower-version-review.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-higher-and-lower-version-review.json.snap
@@ -29,7 +29,8 @@ expression: json
             "raw": "+19",
             "count": 19
           }
-        }
+        },
+        "confident": true
       }
     ],
     "suggest_by_criteria": {
@@ -47,7 +48,8 @@ expression: json
               "raw": "+19",
               "count": 19
             }
-          }
+          },
+          "confident": true
         }
       ]
     },

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-higher-version-review.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-higher-version-review.json.snap
@@ -29,7 +29,8 @@ expression: json
             "raw": "-21",
             "count": 21
           }
-        }
+        },
+        "confident": true
       }
     ],
     "suggest_by_criteria": {
@@ -47,7 +48,8 @@ expression: json
               "raw": "-21",
               "count": 21
             }
-          }
+          },
+          "confident": true
         }
       ]
     },

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-higher-version-review.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-higher-version-review.json.snap
@@ -3,17 +3,35 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (vetting)",
   "failures": [
     {
+      "name": "third-party1",
+      "version": "10.0.0",
       "missing_criteria": [
         "reviewed"
-      ],
-      "name": "third-party1",
-      "version": "10.0.0"
+      ]
     }
   ],
   "suggest": {
+    "suggestions": [
+      {
+        "name": "third-party1",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "from": "11.0.0",
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "-21",
+            "count": 21
+          }
+        }
+      }
+    ],
     "suggest_by_criteria": {
       "reviewed": [
         {
@@ -23,33 +41,16 @@ expression: json
             "reviewed"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 21,
-              "raw": "-21"
-            },
             "from": "11.0.0",
-            "to": "10.0.0"
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "-21",
+              "count": 21
+            }
           }
         }
       ]
     },
-    "suggestions": [
-      {
-        "name": "third-party1",
-        "notable_parents": "first-party",
-        "suggested_criteria": [
-          "reviewed"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 21,
-            "raw": "-21"
-          },
-          "from": "11.0.0",
-          "to": "10.0.0"
-        }
-      }
-    ],
     "total_lines": 21
   }
 }

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-init.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-init.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [],
   "vetted_partially": [],

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-lower-version-review.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-lower-version-review.json.snap
@@ -3,17 +3,35 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (vetting)",
   "failures": [
     {
+      "name": "third-party1",
+      "version": "10.0.0",
       "missing_criteria": [
         "reviewed"
-      ],
-      "name": "third-party1",
-      "version": "10.0.0"
+      ]
     }
   ],
   "suggest": {
+    "suggestions": [
+      {
+        "name": "third-party1",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "from": "9.0.0",
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+19",
+            "count": 19
+          }
+        }
+      }
+    ],
     "suggest_by_criteria": {
       "reviewed": [
         {
@@ -23,33 +41,16 @@ expression: json
             "reviewed"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 19,
-              "raw": "+19"
-            },
             "from": "9.0.0",
-            "to": "10.0.0"
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+19",
+              "count": 19
+            }
           }
         }
       ]
     },
-    "suggestions": [
-      {
-        "name": "third-party1",
-        "notable_parents": "first-party",
-        "suggested_criteria": [
-          "reviewed"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 19,
-            "raw": "+19"
-          },
-          "from": "9.0.0",
-          "to": "10.0.0"
-        }
-      }
-    ],
     "total_lines": 19
   }
 }

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-lower-version-review.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-lower-version-review.json.snap
@@ -29,7 +29,8 @@ expression: json
             "raw": "+19",
             "count": 19
           }
-        }
+        },
+        "confident": true
       }
     ],
     "suggest_by_criteria": {
@@ -47,7 +48,8 @@ expression: json
               "raw": "+19",
               "count": 19
             }
-          }
+          },
+          "confident": true
         }
       ]
     },

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-missing-direct-internal.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-missing-direct-internal.json.snap
@@ -3,17 +3,35 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (vetting)",
   "failures": [
     {
+      "name": "third-party1",
+      "version": "10.0.0",
       "missing_criteria": [
         "reviewed"
-      ],
-      "name": "third-party1",
-      "version": "10.0.0"
+      ]
     }
   ],
   "suggest": {
+    "suggestions": [
+      {
+        "name": "third-party1",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
+        }
+      }
+    ],
     "suggest_by_criteria": {
       "reviewed": [
         {
@@ -23,33 +41,16 @@ expression: json
             "reviewed"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
             "from": null,
-            "to": "10.0.0"
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
           }
         }
       ]
     },
-    "suggestions": [
-      {
-        "name": "third-party1",
-        "notable_parents": "first-party",
-        "suggested_criteria": [
-          "reviewed"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
-          "from": null,
-          "to": "10.0.0"
-        }
-      }
-    ],
     "total_lines": 100
   }
 }

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-missing-direct-internal.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-missing-direct-internal.json.snap
@@ -29,7 +29,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": true
       }
     ],
     "suggest_by_criteria": {
@@ -47,7 +48,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": true
         }
       ]
     },

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-missing-direct-leaf.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-missing-direct-leaf.json.snap
@@ -29,7 +29,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": true
       }
     ],
     "suggest_by_criteria": {
@@ -47,7 +48,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": true
         }
       ]
     },

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-missing-direct-leaf.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-missing-direct-leaf.json.snap
@@ -3,17 +3,35 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (vetting)",
   "failures": [
     {
+      "name": "third-party2",
+      "version": "10.0.0",
       "missing_criteria": [
         "reviewed"
-      ],
-      "name": "third-party2",
-      "version": "10.0.0"
+      ]
     }
   ],
   "suggest": {
+    "suggestions": [
+      {
+        "name": "third-party2",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
+        }
+      }
+    ],
     "suggest_by_criteria": {
       "reviewed": [
         {
@@ -23,33 +41,16 @@ expression: json
             "reviewed"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
             "from": null,
-            "to": "10.0.0"
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
           }
         }
       ]
     },
-    "suggestions": [
-      {
-        "name": "third-party2",
-        "notable_parents": "first-party",
-        "suggested_criteria": [
-          "reviewed"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
-          "from": null,
-          "to": "10.0.0"
-        }
-      }
-    ],
     "total_lines": 100
   }
 }

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-missing-leaves.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-missing-leaves.json.snap
@@ -3,58 +3,25 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (vetting)",
   "failures": [
     {
+      "name": "third-party2",
+      "version": "10.0.0",
       "missing_criteria": [
         "reviewed"
-      ],
-      "name": "third-party2",
-      "version": "10.0.0"
+      ]
     },
     {
+      "name": "transitive-third-party1",
+      "version": "10.0.0",
       "missing_criteria": [
         "reviewed"
-      ],
-      "name": "transitive-third-party1",
-      "version": "10.0.0"
+      ]
     }
   ],
   "suggest": {
-    "suggest_by_criteria": {
-      "reviewed": [
-        {
-          "name": "third-party2",
-          "notable_parents": "first-party",
-          "suggested_criteria": [
-            "reviewed"
-          ],
-          "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
-            "from": null,
-            "to": "10.0.0"
-          }
-        },
-        {
-          "name": "transitive-third-party1",
-          "notable_parents": "third-party1",
-          "suggested_criteria": [
-            "reviewed"
-          ],
-          "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
-            "from": null,
-            "to": "10.0.0"
-          }
-        }
-      ]
-    },
     "suggestions": [
       {
         "name": "third-party2",
@@ -63,12 +30,12 @@ expression: json
           "reviewed"
         ],
         "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
           "from": null,
-          "to": "10.0.0"
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
         }
       },
       {
@@ -78,15 +45,49 @@ expression: json
           "reviewed"
         ],
         "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
           "from": null,
-          "to": "10.0.0"
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
         }
       }
     ],
+    "suggest_by_criteria": {
+      "reviewed": [
+        {
+          "name": "third-party2",
+          "notable_parents": "first-party",
+          "suggested_criteria": [
+            "reviewed"
+          ],
+          "suggested_diff": {
+            "from": null,
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
+          }
+        },
+        {
+          "name": "transitive-third-party1",
+          "notable_parents": "third-party1",
+          "suggested_criteria": [
+            "reviewed"
+          ],
+          "suggested_diff": {
+            "from": null,
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
+          }
+        }
+      ]
+    },
     "total_lines": 200
   }
 }

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-missing-leaves.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-missing-leaves.json.snap
@@ -36,7 +36,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": true
       },
       {
         "name": "transitive-third-party1",
@@ -51,7 +52,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": true
       }
     ],
     "suggest_by_criteria": {
@@ -69,7 +71,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": true
         },
         {
           "name": "transitive-third-party1",
@@ -84,7 +87,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": true
         }
       ]
     },

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-missing-transitive.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-missing-transitive.json.snap
@@ -29,7 +29,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": true
       }
     ],
     "suggest_by_criteria": {
@@ -47,7 +48,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": true
         }
       ]
     },

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-missing-transitive.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-missing-transitive.json.snap
@@ -3,17 +3,35 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (vetting)",
   "failures": [
     {
+      "name": "transitive-third-party1",
+      "version": "10.0.0",
       "missing_criteria": [
         "reviewed"
-      ],
-      "name": "transitive-third-party1",
-      "version": "10.0.0"
+      ]
     }
   ],
   "suggest": {
+    "suggestions": [
+      {
+        "name": "transitive-third-party1",
+        "notable_parents": "third-party1",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
+        }
+      }
+    ],
     "suggest_by_criteria": {
       "reviewed": [
         {
@@ -23,33 +41,16 @@ expression: json
             "reviewed"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
             "from": null,
-            "to": "10.0.0"
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
           }
         }
       ]
     },
-    "suggestions": [
-      {
-        "name": "transitive-third-party1",
-        "notable_parents": "third-party1",
-        "suggested_criteria": [
-          "reviewed"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
-          "from": null,
-          "to": "10.0.0"
-        }
-      }
-    ],
     "total_lines": 100
   }
 }

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-needed-reversed-delta-to-unaudited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-needed-reversed-delta-to-unaudited.json.snap
@@ -3,17 +3,35 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (vetting)",
   "failures": [
     {
+      "name": "third-party1",
+      "version": "10.0.0",
       "missing_criteria": [
         "reviewed"
-      ],
-      "name": "third-party1",
-      "version": "10.0.0"
+      ]
     }
   ],
   "suggest": {
+    "suggestions": [
+      {
+        "name": "third-party1",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
+        }
+      }
+    ],
     "suggest_by_criteria": {
       "reviewed": [
         {
@@ -23,33 +41,16 @@ expression: json
             "reviewed"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
             "from": null,
-            "to": "10.0.0"
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
           }
         }
       ]
     },
-    "suggestions": [
-      {
-        "name": "third-party1",
-        "notable_parents": "first-party",
-        "suggested_criteria": [
-          "reviewed"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
-          "from": null,
-          "to": "10.0.0"
-        }
-      }
-    ],
     "total_lines": 100
   }
 }

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-needed-reversed-delta-to-unaudited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-needed-reversed-delta-to-unaudited.json.snap
@@ -29,7 +29,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": true
       }
     ],
     "suggest_by_criteria": {
@@ -47,7 +48,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": true
         }
       ]
     },

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-no-unaudited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-no-unaudited.json.snap
@@ -3,58 +3,25 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (vetting)",
   "failures": [
     {
+      "name": "third-party1",
+      "version": "10.0.0",
       "missing_criteria": [
         "reviewed"
-      ],
-      "name": "third-party1",
-      "version": "10.0.0"
+      ]
     },
     {
+      "name": "third-party2",
+      "version": "10.0.0",
       "missing_criteria": [
         "reviewed"
-      ],
-      "name": "third-party2",
-      "version": "10.0.0"
+      ]
     }
   ],
   "suggest": {
-    "suggest_by_criteria": {
-      "reviewed": [
-        {
-          "name": "third-party1",
-          "notable_parents": "first-party",
-          "suggested_criteria": [
-            "reviewed"
-          ],
-          "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
-            "from": null,
-            "to": "10.0.0"
-          }
-        },
-        {
-          "name": "third-party2",
-          "notable_parents": "first-party",
-          "suggested_criteria": [
-            "reviewed"
-          ],
-          "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
-            "from": null,
-            "to": "10.0.0"
-          }
-        }
-      ]
-    },
     "suggestions": [
       {
         "name": "third-party1",
@@ -63,12 +30,12 @@ expression: json
           "reviewed"
         ],
         "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
           "from": null,
-          "to": "10.0.0"
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
         }
       },
       {
@@ -78,15 +45,49 @@ expression: json
           "reviewed"
         ],
         "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
           "from": null,
-          "to": "10.0.0"
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
         }
       }
     ],
+    "suggest_by_criteria": {
+      "reviewed": [
+        {
+          "name": "third-party1",
+          "notable_parents": "first-party",
+          "suggested_criteria": [
+            "reviewed"
+          ],
+          "suggested_diff": {
+            "from": null,
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
+          }
+        },
+        {
+          "name": "third-party2",
+          "notable_parents": "first-party",
+          "suggested_criteria": [
+            "reviewed"
+          ],
+          "suggested_diff": {
+            "from": null,
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
+          }
+        }
+      ]
+    },
     "total_lines": 200
   }
 }

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-no-unaudited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-no-unaudited.json.snap
@@ -36,7 +36,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": true
       },
       {
         "name": "third-party2",
@@ -51,7 +52,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": true
       }
     ],
     "suggest_by_criteria": {
@@ -69,7 +71,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": true
         },
         {
           "name": "third-party2",
@@ -84,7 +87,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": true
         }
       ]
     },

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-reverse-delta-to-full-audit.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-reverse-delta-to-full-audit.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [
     {

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-reverse-delta-to-unaudited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-reverse-delta-to-unaudited.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [
     {

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-reviewed-too-weakly.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-reviewed-too-weakly.json.snap
@@ -29,7 +29,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": true
       }
     ],
     "suggest_by_criteria": {
@@ -47,7 +48,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": true
         }
       ]
     },

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-reviewed-too-weakly.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-reviewed-too-weakly.json.snap
@@ -3,17 +3,35 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (vetting)",
   "failures": [
     {
+      "name": "transitive-third-party1",
+      "version": "10.0.0",
       "missing_criteria": [
         "reviewed"
-      ],
-      "name": "transitive-third-party1",
-      "version": "10.0.0"
+      ]
     }
   ],
   "suggest": {
+    "suggestions": [
+      {
+        "name": "transitive-third-party1",
+        "notable_parents": "third-party1",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
+        }
+      }
+    ],
     "suggest_by_criteria": {
       "reviewed": [
         {
@@ -23,33 +41,16 @@ expression: json
             "reviewed"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
             "from": null,
-            "to": "10.0.0"
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
           }
         }
       ]
     },
-    "suggestions": [
-      {
-        "name": "transitive-third-party1",
-        "notable_parents": "third-party1",
-        "suggested_criteria": [
-          "reviewed"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
-          "from": null,
-          "to": "10.0.0"
-        }
-      }
-    ],
     "total_lines": 100
   }
 }

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-weaker-transitive-req-using-implies.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-weaker-transitive-req-using-implies.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [
     {

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-weaker-transitive-req.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-weaker-transitive-req.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [
     {

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-wrongly-reversed-delta-to-full-audit.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-wrongly-reversed-delta-to-full-audit.json.snap
@@ -29,7 +29,8 @@ expression: json
             "raw": "+75",
             "count": 75
           }
-        }
+        },
+        "confident": true
       }
     ],
     "suggest_by_criteria": {
@@ -47,7 +48,8 @@ expression: json
               "raw": "+75",
               "count": 75
             }
-          }
+          },
+          "confident": true
         }
       ]
     },

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-wrongly-reversed-delta-to-full-audit.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-wrongly-reversed-delta-to-full-audit.json.snap
@@ -3,17 +3,35 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (vetting)",
   "failures": [
     {
+      "name": "third-party1",
+      "version": "10.0.0",
       "missing_criteria": [
         "reviewed"
-      ],
-      "name": "third-party1",
-      "version": "10.0.0"
+      ]
     }
   ],
   "suggest": {
+    "suggestions": [
+      {
+        "name": "third-party1",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "from": "5.0.0",
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+75",
+            "count": 75
+          }
+        }
+      }
+    ],
     "suggest_by_criteria": {
       "reviewed": [
         {
@@ -23,33 +41,16 @@ expression: json
             "reviewed"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 75,
-              "raw": "+75"
-            },
             "from": "5.0.0",
-            "to": "10.0.0"
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+75",
+              "count": 75
+            }
           }
         }
       ]
     },
-    "suggestions": [
-      {
-        "name": "third-party1",
-        "notable_parents": "first-party",
-        "suggested_criteria": [
-          "reviewed"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 75,
-            "raw": "+75"
-          },
-          "from": "5.0.0",
-          "to": "10.0.0"
-        }
-      }
-    ],
     "total_lines": 75
   }
 }

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-wrongly-reversed-delta-to-unaudited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-wrongly-reversed-delta-to-unaudited.json.snap
@@ -29,7 +29,8 @@ expression: json
             "raw": "+75",
             "count": 75
           }
-        }
+        },
+        "confident": true
       }
     ],
     "suggest_by_criteria": {
@@ -47,7 +48,8 @@ expression: json
               "raw": "+75",
               "count": 75
             }
-          }
+          },
+          "confident": true
         }
       ]
     },

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-wrongly-reversed-delta-to-unaudited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-wrongly-reversed-delta-to-unaudited.json.snap
@@ -3,17 +3,35 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (vetting)",
   "failures": [
     {
+      "name": "third-party1",
+      "version": "10.0.0",
       "missing_criteria": [
         "reviewed"
-      ],
-      "name": "third-party1",
-      "version": "10.0.0"
+      ]
     }
   ],
   "suggest": {
+    "suggestions": [
+      {
+        "name": "third-party1",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "from": "5.0.0",
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+75",
+            "count": 75
+          }
+        }
+      }
+    ],
     "suggest_by_criteria": {
       "reviewed": [
         {
@@ -23,33 +41,16 @@ expression: json
             "reviewed"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 75,
-              "raw": "+75"
-            },
             "from": "5.0.0",
-            "to": "10.0.0"
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+75",
+              "count": 75
+            }
           }
         }
       ]
     },
-    "suggestions": [
-      {
-        "name": "third-party1",
-        "notable_parents": "first-party",
-        "suggested_criteria": [
-          "reviewed"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 75,
-            "raw": "+75"
-          },
-          "from": "5.0.0",
-          "to": "10.0.0"
-        }
-      }
-    ],
     "total_lines": 75
   }
 }

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock_simple_foreign_audited_pun_mapped.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock_simple_foreign_audited_pun_mapped.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [
     {

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock_simple_foreign_audited_pun_no_mapping.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock_simple_foreign_audited_pun_no_mapping.json.snap
@@ -3,58 +3,25 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (vetting)",
   "failures": [
     {
+      "name": "third-party1",
+      "version": "10.0.0",
       "missing_criteria": [
         "reviewed"
-      ],
-      "name": "third-party1",
-      "version": "10.0.0"
+      ]
     },
     {
+      "name": "third-party2",
+      "version": "10.0.0",
       "missing_criteria": [
         "reviewed"
-      ],
-      "name": "third-party2",
-      "version": "10.0.0"
+      ]
     }
   ],
   "suggest": {
-    "suggest_by_criteria": {
-      "reviewed": [
-        {
-          "name": "third-party1",
-          "notable_parents": "first-party",
-          "suggested_criteria": [
-            "reviewed"
-          ],
-          "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
-            "from": null,
-            "to": "10.0.0"
-          }
-        },
-        {
-          "name": "third-party2",
-          "notable_parents": "first-party",
-          "suggested_criteria": [
-            "reviewed"
-          ],
-          "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
-            "from": null,
-            "to": "10.0.0"
-          }
-        }
-      ]
-    },
     "suggestions": [
       {
         "name": "third-party1",
@@ -63,12 +30,12 @@ expression: json
           "reviewed"
         ],
         "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
           "from": null,
-          "to": "10.0.0"
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
         }
       },
       {
@@ -78,15 +45,49 @@ expression: json
           "reviewed"
         ],
         "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
           "from": null,
-          "to": "10.0.0"
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
         }
       }
     ],
+    "suggest_by_criteria": {
+      "reviewed": [
+        {
+          "name": "third-party1",
+          "notable_parents": "first-party",
+          "suggested_criteria": [
+            "reviewed"
+          ],
+          "suggested_diff": {
+            "from": null,
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
+          }
+        },
+        {
+          "name": "third-party2",
+          "notable_parents": "first-party",
+          "suggested_criteria": [
+            "reviewed"
+          ],
+          "suggested_diff": {
+            "from": null,
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
+          }
+        }
+      ]
+    },
     "total_lines": 200
   }
 }

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock_simple_foreign_audited_pun_no_mapping.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock_simple_foreign_audited_pun_no_mapping.json.snap
@@ -36,7 +36,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": true
       },
       {
         "name": "third-party2",
@@ -51,7 +52,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": true
       }
     ],
     "suggest_by_criteria": {
@@ -69,7 +71,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": true
         },
         {
           "name": "third-party2",
@@ -84,7 +87,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": true
         }
       ]
     },

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock_simple_foreign_audited_pun_wrong_mapped.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock_simple_foreign_audited_pun_wrong_mapped.json.snap
@@ -3,58 +3,25 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (vetting)",
   "failures": [
     {
+      "name": "third-party1",
+      "version": "10.0.0",
       "missing_criteria": [
         "reviewed"
-      ],
-      "name": "third-party1",
-      "version": "10.0.0"
+      ]
     },
     {
+      "name": "third-party2",
+      "version": "10.0.0",
       "missing_criteria": [
         "reviewed"
-      ],
-      "name": "third-party2",
-      "version": "10.0.0"
+      ]
     }
   ],
   "suggest": {
-    "suggest_by_criteria": {
-      "reviewed": [
-        {
-          "name": "third-party1",
-          "notable_parents": "first-party",
-          "suggested_criteria": [
-            "reviewed"
-          ],
-          "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
-            "from": null,
-            "to": "10.0.0"
-          }
-        },
-        {
-          "name": "third-party2",
-          "notable_parents": "first-party",
-          "suggested_criteria": [
-            "reviewed"
-          ],
-          "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
-            "from": null,
-            "to": "10.0.0"
-          }
-        }
-      ]
-    },
     "suggestions": [
       {
         "name": "third-party1",
@@ -63,12 +30,12 @@ expression: json
           "reviewed"
         ],
         "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
           "from": null,
-          "to": "10.0.0"
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
         }
       },
       {
@@ -78,15 +45,49 @@ expression: json
           "reviewed"
         ],
         "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
           "from": null,
-          "to": "10.0.0"
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
         }
       }
     ],
+    "suggest_by_criteria": {
+      "reviewed": [
+        {
+          "name": "third-party1",
+          "notable_parents": "first-party",
+          "suggested_criteria": [
+            "reviewed"
+          ],
+          "suggested_diff": {
+            "from": null,
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
+          }
+        },
+        {
+          "name": "third-party2",
+          "notable_parents": "first-party",
+          "suggested_criteria": [
+            "reviewed"
+          ],
+          "suggested_diff": {
+            "from": null,
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
+          }
+        }
+      ]
+    },
     "total_lines": 200
   }
 }

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock_simple_foreign_audited_pun_wrong_mapped.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock_simple_foreign_audited_pun_wrong_mapped.json.snap
@@ -36,7 +36,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": true
       },
       {
         "name": "third-party2",
@@ -51,7 +52,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": true
       }
     ],
     "suggest_by_criteria": {
@@ -69,7 +71,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": true
         },
         {
           "name": "third-party2",
@@ -84,7 +87,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": true
         }
       ]
     },

--- a/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-dep-extra-missing.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-dep-extra-missing.json.snap
@@ -3,17 +3,35 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (vetting)",
   "failures": [
     {
+      "name": "third-party2",
+      "version": "10.0.0",
       "missing_criteria": [
         "fuzzed"
-      ],
-      "name": "third-party2",
-      "version": "10.0.0"
+      ]
     }
   ],
   "suggest": {
+    "suggestions": [
+      {
+        "name": "third-party2",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "fuzzed"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
+        }
+      }
+    ],
     "suggest_by_criteria": {
       "fuzzed": [
         {
@@ -23,33 +41,16 @@ expression: json
             "fuzzed"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
             "from": null,
-            "to": "10.0.0"
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
           }
         }
       ]
     },
-    "suggestions": [
-      {
-        "name": "third-party2",
-        "notable_parents": "first-party",
-        "suggested_criteria": [
-          "fuzzed"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
-          "from": null,
-          "to": "10.0.0"
-        }
-      }
-    ],
     "total_lines": 100
   }
 }

--- a/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-dep-extra-missing.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-dep-extra-missing.json.snap
@@ -29,7 +29,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": true
       }
     ],
     "suggest_by_criteria": {
@@ -47,7 +48,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": true
         }
       ]
     },

--- a/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-dep-extra.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-dep-extra.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [
     {

--- a/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-dep-stronger.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-dep-stronger.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [
     {

--- a/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-dep-too-strong.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-dep-too-strong.json.snap
@@ -3,17 +3,35 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (vetting)",
   "failures": [
     {
+      "name": "third-party1",
+      "version": "10.0.0",
       "missing_criteria": [
         "strong-reviewed"
-      ],
-      "name": "third-party1",
-      "version": "10.0.0"
+      ]
     }
   ],
   "suggest": {
+    "suggestions": [
+      {
+        "name": "third-party1",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "strong-reviewed"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
+        }
+      }
+    ],
     "suggest_by_criteria": {
       "strong-reviewed": [
         {
@@ -23,33 +41,16 @@ expression: json
             "strong-reviewed"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
             "from": null,
-            "to": "10.0.0"
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
           }
         }
       ]
     },
-    "suggestions": [
-      {
-        "name": "third-party1",
-        "notable_parents": "first-party",
-        "suggested_criteria": [
-          "strong-reviewed"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
-          "from": null,
-          "to": "10.0.0"
-        }
-      }
-    ],
     "total_lines": 100
   }
 }

--- a/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-dep-too-strong.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-dep-too-strong.json.snap
@@ -29,7 +29,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": true
       }
     ],
     "suggest_by_criteria": {
@@ -47,7 +48,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": true
         }
       ]
     },

--- a/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-dep-weaker-needed.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-dep-weaker-needed.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [
     {

--- a/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-dep-weaker.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-dep-weaker.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [
     {

--- a/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-extra-partially-missing.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-extra-partially-missing.json.snap
@@ -3,17 +3,35 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (vetting)",
   "failures": [
     {
+      "name": "third-party1",
+      "version": "10.0.0",
       "missing_criteria": [
         "fuzzed"
-      ],
-      "name": "third-party1",
-      "version": "10.0.0"
+      ]
     }
   ],
   "suggest": {
+    "suggestions": [
+      {
+        "name": "third-party1",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "fuzzed"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
+        }
+      }
+    ],
     "suggest_by_criteria": {
       "fuzzed": [
         {
@@ -23,33 +41,16 @@ expression: json
             "fuzzed"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
             "from": null,
-            "to": "10.0.0"
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
           }
         }
       ]
     },
-    "suggestions": [
-      {
-        "name": "third-party1",
-        "notable_parents": "first-party",
-        "suggested_criteria": [
-          "fuzzed"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
-          "from": null,
-          "to": "10.0.0"
-        }
-      }
-    ],
     "total_lines": 100
   }
 }

--- a/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-extra-partially-missing.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-extra-partially-missing.json.snap
@@ -29,7 +29,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": true
       }
     ],
     "suggest_by_criteria": {
@@ -47,7 +48,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": true
         }
       ]
     },

--- a/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-policy-redundant.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-policy-redundant.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [
     {

--- a/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-too-strong.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-too-strong.json.snap
@@ -3,58 +3,25 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (vetting)",
   "failures": [
     {
+      "name": "third-party1",
+      "version": "10.0.0",
       "missing_criteria": [
         "strong-reviewed"
-      ],
-      "name": "third-party1",
-      "version": "10.0.0"
+      ]
     },
     {
+      "name": "third-party2",
+      "version": "10.0.0",
       "missing_criteria": [
         "strong-reviewed"
-      ],
-      "name": "third-party2",
-      "version": "10.0.0"
+      ]
     }
   ],
   "suggest": {
-    "suggest_by_criteria": {
-      "strong-reviewed": [
-        {
-          "name": "third-party1",
-          "notable_parents": "first-party",
-          "suggested_criteria": [
-            "strong-reviewed"
-          ],
-          "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
-            "from": null,
-            "to": "10.0.0"
-          }
-        },
-        {
-          "name": "third-party2",
-          "notable_parents": "first-party",
-          "suggested_criteria": [
-            "strong-reviewed"
-          ],
-          "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
-            "from": null,
-            "to": "10.0.0"
-          }
-        }
-      ]
-    },
     "suggestions": [
       {
         "name": "third-party1",
@@ -63,12 +30,12 @@ expression: json
           "strong-reviewed"
         ],
         "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
           "from": null,
-          "to": "10.0.0"
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
         }
       },
       {
@@ -78,15 +45,49 @@ expression: json
           "strong-reviewed"
         ],
         "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
           "from": null,
-          "to": "10.0.0"
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
         }
       }
     ],
+    "suggest_by_criteria": {
+      "strong-reviewed": [
+        {
+          "name": "third-party1",
+          "notable_parents": "first-party",
+          "suggested_criteria": [
+            "strong-reviewed"
+          ],
+          "suggested_diff": {
+            "from": null,
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
+          }
+        },
+        {
+          "name": "third-party2",
+          "notable_parents": "first-party",
+          "suggested_criteria": [
+            "strong-reviewed"
+          ],
+          "suggested_diff": {
+            "from": null,
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
+          }
+        }
+      ]
+    },
     "total_lines": 200
   }
 }

--- a/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-too-strong.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-too-strong.json.snap
@@ -36,7 +36,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": true
       },
       {
         "name": "third-party2",
@@ -51,7 +52,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": true
       }
     ],
     "suggest_by_criteria": {
@@ -69,7 +71,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": true
         },
         {
           "name": "third-party2",
@@ -84,7 +87,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": true
         }
       ]
     },

--- a/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-weaker.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-weaker.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [
     {

--- a/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-root-dep-too-strong.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-root-dep-too-strong.json.snap
@@ -3,58 +3,25 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (vetting)",
   "failures": [
     {
+      "name": "third-party1",
+      "version": "10.0.0",
       "missing_criteria": [
         "strong-reviewed"
-      ],
-      "name": "third-party1",
-      "version": "10.0.0"
+      ]
     },
     {
+      "name": "third-party2",
+      "version": "10.0.0",
       "missing_criteria": [
         "strong-reviewed"
-      ],
-      "name": "third-party2",
-      "version": "10.0.0"
+      ]
     }
   ],
   "suggest": {
-    "suggest_by_criteria": {
-      "strong-reviewed": [
-        {
-          "name": "third-party1",
-          "notable_parents": "first-party",
-          "suggested_criteria": [
-            "strong-reviewed"
-          ],
-          "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
-            "from": null,
-            "to": "10.0.0"
-          }
-        },
-        {
-          "name": "third-party2",
-          "notable_parents": "first-party",
-          "suggested_criteria": [
-            "strong-reviewed"
-          ],
-          "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
-            "from": null,
-            "to": "10.0.0"
-          }
-        }
-      ]
-    },
     "suggestions": [
       {
         "name": "third-party1",
@@ -63,12 +30,12 @@ expression: json
           "strong-reviewed"
         ],
         "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
           "from": null,
-          "to": "10.0.0"
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
         }
       },
       {
@@ -78,15 +45,49 @@ expression: json
           "strong-reviewed"
         ],
         "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
           "from": null,
-          "to": "10.0.0"
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
         }
       }
     ],
+    "suggest_by_criteria": {
+      "strong-reviewed": [
+        {
+          "name": "third-party1",
+          "notable_parents": "first-party",
+          "suggested_criteria": [
+            "strong-reviewed"
+          ],
+          "suggested_diff": {
+            "from": null,
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
+          }
+        },
+        {
+          "name": "third-party2",
+          "notable_parents": "first-party",
+          "suggested_criteria": [
+            "strong-reviewed"
+          ],
+          "suggested_diff": {
+            "from": null,
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
+          }
+        }
+      ]
+    },
     "total_lines": 200
   }
 }

--- a/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-root-dep-too-strong.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-root-dep-too-strong.json.snap
@@ -36,7 +36,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": true
       },
       {
         "name": "third-party2",
@@ -51,7 +52,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": true
       }
     ],
     "suggest_by_criteria": {
@@ -69,7 +71,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": true
         },
         {
           "name": "third-party2",
@@ -84,7 +87,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": true
         }
       ]
     },

--- a/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-root-dep-weaker.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-root-dep-weaker.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [
     {

--- a/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-root-too-strong.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-root-too-strong.json.snap
@@ -3,58 +3,25 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (vetting)",
   "failures": [
     {
+      "name": "third-party1",
+      "version": "10.0.0",
       "missing_criteria": [
         "strong-reviewed"
-      ],
-      "name": "third-party1",
-      "version": "10.0.0"
+      ]
     },
     {
+      "name": "third-party2",
+      "version": "10.0.0",
       "missing_criteria": [
         "strong-reviewed"
-      ],
-      "name": "third-party2",
-      "version": "10.0.0"
+      ]
     }
   ],
   "suggest": {
-    "suggest_by_criteria": {
-      "strong-reviewed": [
-        {
-          "name": "third-party1",
-          "notable_parents": "first-party",
-          "suggested_criteria": [
-            "strong-reviewed"
-          ],
-          "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
-            "from": null,
-            "to": "10.0.0"
-          }
-        },
-        {
-          "name": "third-party2",
-          "notable_parents": "first-party",
-          "suggested_criteria": [
-            "strong-reviewed"
-          ],
-          "suggested_diff": {
-            "diffstat": {
-              "count": 100,
-              "raw": "+100"
-            },
-            "from": null,
-            "to": "10.0.0"
-          }
-        }
-      ]
-    },
     "suggestions": [
       {
         "name": "third-party1",
@@ -63,12 +30,12 @@ expression: json
           "strong-reviewed"
         ],
         "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
           "from": null,
-          "to": "10.0.0"
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
         }
       },
       {
@@ -78,15 +45,49 @@ expression: json
           "strong-reviewed"
         ],
         "suggested_diff": {
-          "diffstat": {
-            "count": 100,
-            "raw": "+100"
-          },
           "from": null,
-          "to": "10.0.0"
+          "to": "10.0.0",
+          "diffstat": {
+            "raw": "+100",
+            "count": 100
+          }
         }
       }
     ],
+    "suggest_by_criteria": {
+      "strong-reviewed": [
+        {
+          "name": "third-party1",
+          "notable_parents": "first-party",
+          "suggested_criteria": [
+            "strong-reviewed"
+          ],
+          "suggested_diff": {
+            "from": null,
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
+          }
+        },
+        {
+          "name": "third-party2",
+          "notable_parents": "first-party",
+          "suggested_criteria": [
+            "strong-reviewed"
+          ],
+          "suggested_diff": {
+            "from": null,
+            "to": "10.0.0",
+            "diffstat": {
+              "raw": "+100",
+              "count": 100
+            }
+          }
+        }
+      ]
+    },
     "total_lines": 200
   }
 }

--- a/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-root-too-strong.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-root-too-strong.json.snap
@@ -36,7 +36,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": true
       },
       {
         "name": "third-party2",
@@ -51,7 +52,8 @@ expression: json
             "raw": "+100",
             "count": 100
           }
-        }
+        },
+        "confident": true
       }
     ],
     "suggest_by_criteria": {
@@ -69,7 +71,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": true
         },
         {
           "name": "third-party2",
@@ -84,7 +87,8 @@ expression: json
               "raw": "+100",
               "count": 100
             }
-          }
+          },
+          "confident": true
         }
       ]
     },

--- a/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-root-weaker.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-root-weaker.json.snap
@@ -3,6 +3,7 @@ source: src/tests/vet.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [
     {

--- a/src/tests/snapshots/cargo_vet__tests__violations__builtin-simple-deps-violation-dodged.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__violations__builtin-simple-deps-violation-dodged.json.snap
@@ -3,6 +3,7 @@ source: src/tests/violations.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [
     {

--- a/src/tests/snapshots/cargo_vet__tests__violations__builtin-simple-deps-violation-high-hit.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__violations__builtin-simple-deps-violation-high-hit.json.snap
@@ -3,27 +3,28 @@ source: src/tests/violations.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (violation)",
   "violations": {
     "dev:10.0.0": [
       {
         "AuditConflict": {
-          "audit": {
-            "criteria": "safe-to-deploy",
-            "delta": null,
-            "notes": null,
-            "version": "10.0.0",
-            "violation": null
-          },
-          "audit_source": "Local",
+          "violation_source": "Local",
           "violation": {
             "criteria": "safe-to-deploy",
-            "delta": null,
-            "notes": null,
             "version": null,
-            "violation": "*"
+            "delta": null,
+            "violation": "*",
+            "notes": null
           },
-          "violation_source": "Local"
+          "audit_source": "Local",
+          "audit": {
+            "criteria": "safe-to-deploy",
+            "version": "10.0.0",
+            "delta": null,
+            "violation": null,
+            "notes": null
+          }
         }
       }
     ]

--- a/src/tests/snapshots/cargo_vet__tests__violations__builtin-simple-deps-violation-imply-hit.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__violations__builtin-simple-deps-violation-imply-hit.json.snap
@@ -3,27 +3,28 @@ source: src/tests/violations.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (violation)",
   "violations": {
     "dev:10.0.0": [
       {
         "AuditConflict": {
-          "audit": {
-            "criteria": "safe-to-deploy",
-            "delta": null,
-            "notes": null,
-            "version": "10.0.0",
-            "violation": null
-          },
-          "audit_source": "Local",
+          "violation_source": "Local",
           "violation": {
             "criteria": "safe-to-run",
-            "delta": null,
-            "notes": null,
             "version": null,
-            "violation": "*"
+            "delta": null,
+            "violation": "*",
+            "notes": null
           },
-          "violation_source": "Local"
+          "audit_source": "Local",
+          "audit": {
+            "criteria": "safe-to-deploy",
+            "version": "10.0.0",
+            "delta": null,
+            "violation": null,
+            "notes": null
+          }
         }
       }
     ]

--- a/src/tests/snapshots/cargo_vet__tests__violations__builtin-simple-deps-violation-low-hit.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__violations__builtin-simple-deps-violation-low-hit.json.snap
@@ -3,27 +3,28 @@ source: src/tests/violations.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (violation)",
   "violations": {
     "dev:10.0.0": [
       {
         "AuditConflict": {
-          "audit": {
-            "criteria": "safe-to-run",
-            "delta": null,
-            "notes": null,
-            "version": "10.0.0",
-            "violation": null
-          },
-          "audit_source": "Local",
+          "violation_source": "Local",
           "violation": {
             "criteria": "safe-to-run",
-            "delta": null,
-            "notes": null,
             "version": null,
-            "violation": "*"
+            "delta": null,
+            "violation": "*",
+            "notes": null
           },
-          "violation_source": "Local"
+          "audit_source": "Local",
+          "audit": {
+            "criteria": "safe-to-run",
+            "version": "10.0.0",
+            "delta": null,
+            "violation": null,
+            "notes": null
+          }
         }
       }
     ]

--- a/src/tests/snapshots/cargo_vet__tests__violations__builtin-simple-deps-violation-redundant-low-hit.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__violations__builtin-simple-deps-violation-redundant-low-hit.json.snap
@@ -3,30 +3,31 @@ source: src/tests/violations.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (violation)",
   "violations": {
     "dev:10.0.0": [
       {
         "AuditConflict": {
-          "audit": {
-            "criteria": "safe-to-run",
-            "delta": null,
-            "notes": null,
-            "version": "10.0.0",
-            "violation": null
-          },
-          "audit_source": "Local",
+          "violation_source": "Local",
           "violation": {
             "criteria": [
               "safe-to-run",
               "safe-to-deploy"
             ],
-            "delta": null,
-            "notes": null,
             "version": null,
-            "violation": "*"
+            "delta": null,
+            "violation": "*",
+            "notes": null
           },
-          "violation_source": "Local"
+          "audit_source": "Local",
+          "audit": {
+            "criteria": "safe-to-run",
+            "version": "10.0.0",
+            "delta": null,
+            "violation": null,
+            "notes": null
+          }
         }
       }
     ]

--- a/src/tests/snapshots/cargo_vet__tests__violations__mock-simple-violation-cur-full-audit.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__violations__mock-simple-violation-cur-full-audit.json.snap
@@ -3,27 +3,28 @@ source: src/tests/violations.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (violation)",
   "violations": {
     "third-party1:10.0.0": [
       {
         "AuditConflict": {
-          "audit": {
-            "criteria": "safe-to-deploy",
-            "delta": null,
-            "notes": null,
-            "version": "10.0.0",
-            "violation": null
-          },
-          "audit_source": "Local",
+          "violation_source": "Local",
           "violation": {
             "criteria": "safe-to-run",
-            "delta": null,
-            "notes": null,
             "version": null,
-            "violation": "=10"
+            "delta": null,
+            "violation": "=10",
+            "notes": null
           },
-          "violation_source": "Local"
+          "audit_source": "Local",
+          "audit": {
+            "criteria": "safe-to-deploy",
+            "version": "10.0.0",
+            "delta": null,
+            "violation": null,
+            "notes": null
+          }
         }
       }
     ]

--- a/src/tests/snapshots/cargo_vet__tests__violations__mock-simple-violation-cur-unaudited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__violations__mock-simple-violation-cur-unaudited.json.snap
@@ -3,24 +3,25 @@ source: src/tests/violations.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (violation)",
   "violations": {
     "third-party1:10.0.0": [
       {
         "UnauditedConflict": {
-          "exemptions": {
-            "criteria": "reviewed",
-            "notes": null,
-            "version": "10.0.0"
-          },
+          "violation_source": "Local",
           "violation": {
             "criteria": "weak-reviewed",
-            "delta": null,
-            "notes": null,
             "version": null,
-            "violation": "=10"
+            "delta": null,
+            "violation": "=10",
+            "notes": null
           },
-          "violation_source": "Local"
+          "exemptions": {
+            "version": "10.0.0",
+            "criteria": "reviewed",
+            "notes": null
+          }
         }
       }
     ]

--- a/src/tests/snapshots/cargo_vet__tests__violations__mock-simple-violation-delta.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__violations__mock-simple-violation-delta.json.snap
@@ -3,47 +3,48 @@ source: src/tests/violations.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (violation)",
   "violations": {
     "third-party1:10.0.0": [
       {
         "AuditConflict": {
-          "audit": {
-            "criteria": "safe-to-deploy",
-            "delta": "3.0.0 -> 5.0.0",
-            "notes": null,
-            "version": null,
-            "violation": null
-          },
-          "audit_source": "Local",
+          "violation_source": "Local",
           "violation": {
             "criteria": "safe-to-run",
-            "delta": null,
-            "notes": null,
             "version": null,
-            "violation": "=5.0.0"
+            "delta": null,
+            "violation": "=5.0.0",
+            "notes": null
           },
-          "violation_source": "Local"
+          "audit_source": "Local",
+          "audit": {
+            "criteria": "safe-to-deploy",
+            "version": null,
+            "delta": "3.0.0 -> 5.0.0",
+            "violation": null,
+            "notes": null
+          }
         }
       },
       {
         "AuditConflict": {
-          "audit": {
-            "criteria": "safe-to-deploy",
-            "delta": "5.0.0 -> 10.0.0",
-            "notes": null,
-            "version": null,
-            "violation": null
-          },
-          "audit_source": "Local",
+          "violation_source": "Local",
           "violation": {
             "criteria": "safe-to-run",
-            "delta": null,
-            "notes": null,
             "version": null,
-            "violation": "=5.0.0"
+            "delta": null,
+            "violation": "=5.0.0",
+            "notes": null
           },
-          "violation_source": "Local"
+          "audit_source": "Local",
+          "audit": {
+            "criteria": "safe-to-deploy",
+            "version": null,
+            "delta": "5.0.0 -> 10.0.0",
+            "violation": null,
+            "notes": null
+          }
         }
       }
     ]

--- a/src/tests/snapshots/cargo_vet__tests__violations__mock-simple-violation-full-audit.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__violations__mock-simple-violation-full-audit.json.snap
@@ -3,47 +3,48 @@ source: src/tests/violations.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (violation)",
   "violations": {
     "third-party1:10.0.0": [
       {
         "AuditConflict": {
-          "audit": {
-            "criteria": "safe-to-deploy",
-            "delta": null,
-            "notes": null,
-            "version": "3.0.0",
-            "violation": null
-          },
-          "audit_source": "Local",
+          "violation_source": "Local",
           "violation": {
             "criteria": "safe-to-run",
-            "delta": null,
-            "notes": null,
             "version": null,
-            "violation": "=3.0.0"
+            "delta": null,
+            "violation": "=3.0.0",
+            "notes": null
           },
-          "violation_source": "Local"
+          "audit_source": "Local",
+          "audit": {
+            "criteria": "safe-to-deploy",
+            "version": "3.0.0",
+            "delta": null,
+            "violation": null,
+            "notes": null
+          }
         }
       },
       {
         "AuditConflict": {
-          "audit": {
-            "criteria": "safe-to-deploy",
-            "delta": "3.0.0 -> 5.0.0",
-            "notes": null,
-            "version": null,
-            "violation": null
-          },
-          "audit_source": "Local",
+          "violation_source": "Local",
           "violation": {
             "criteria": "safe-to-run",
-            "delta": null,
-            "notes": null,
             "version": null,
-            "violation": "=3.0.0"
+            "delta": null,
+            "violation": "=3.0.0",
+            "notes": null
           },
-          "violation_source": "Local"
+          "audit_source": "Local",
+          "audit": {
+            "criteria": "safe-to-deploy",
+            "version": null,
+            "delta": "3.0.0 -> 5.0.0",
+            "violation": null,
+            "notes": null
+          }
         }
       }
     ]

--- a/src/tests/snapshots/cargo_vet__tests__violations__mock-simple-violation-hit-with-extra-junk.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__violations__mock-simple-violation-hit-with-extra-junk.json.snap
@@ -3,30 +3,31 @@ source: src/tests/violations.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (violation)",
   "violations": {
     "third-party1:10.0.0": [
       {
         "AuditConflict": {
-          "audit": {
-            "criteria": "safe-to-run",
-            "delta": null,
-            "notes": null,
-            "version": "10.0.0",
-            "violation": null
-          },
-          "audit_source": "Local",
+          "violation_source": "Local",
           "violation": {
             "criteria": [
               "safe-to-run",
               "fuzzed"
             ],
-            "delta": null,
-            "notes": null,
             "version": null,
-            "violation": "*"
+            "delta": null,
+            "violation": "*",
+            "notes": null
           },
-          "violation_source": "Local"
+          "audit_source": "Local",
+          "audit": {
+            "criteria": "safe-to-run",
+            "version": "10.0.0",
+            "delta": null,
+            "violation": null,
+            "notes": null
+          }
         }
       }
     ]

--- a/src/tests/snapshots/cargo_vet__tests__violations__mock-simple-violation-wildcard.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__violations__mock-simple-violation-wildcard.json.snap
@@ -3,27 +3,28 @@ source: src/tests/violations.rs
 expression: json
 ---
 {
+  "context": null,
   "conclusion": "fail (violation)",
   "violations": {
     "third-party1:10.0.0": [
       {
         "AuditConflict": {
-          "audit": {
-            "criteria": "safe-to-deploy",
-            "delta": null,
-            "notes": null,
-            "version": "10.0.0",
-            "violation": null
-          },
-          "audit_source": "Local",
+          "violation_source": "Local",
           "violation": {
             "criteria": "safe-to-run",
-            "delta": null,
-            "notes": null,
             "version": null,
-            "violation": "*"
+            "delta": null,
+            "violation": "*",
+            "notes": null
           },
-          "violation_source": "Local"
+          "audit_source": "Local",
+          "audit": {
+            "criteria": "safe-to-deploy",
+            "version": "10.0.0",
+            "delta": null,
+            "violation": null,
+            "notes": null
+          }
         }
       }
     ]

--- a/tests/snapshots/test_cli__long-help.snap
+++ b/tests/snapshots/test_cli__long-help.snap
@@ -70,7 +70,7 @@ GLOBAL OPTIONS:
             The format of the output
             
             [default: human]
-            [possible values: human, json]
+            [possible values: human, json, json-full]
 
         --diff-cache <DIFF_CACHE>
             Use the following path as the diff-cache
@@ -149,6 +149,8 @@ SUBCOMMANDS:
             Reformat all of vet's files (in case you hand-edited them)
     fetch-imports
             Explicitly fetch the imports (foreign audit files)
+    aggregate
+            Fetch and merge audits from multiple sources into a single `audits.toml` file
     dump-graph
             Print the cargo build graph as understood by `cargo vet`
     gc

--- a/tests/snapshots/test_cli__long-help.snap
+++ b/tests/snapshots/test_cli__long-help.snap
@@ -31,6 +31,9 @@ GLOBAL OPTIONS:
         --manifest-path <PATH>
             Path to Cargo.toml
 
+        --with-metadata <WITH_METADATA>
+            Instead of running cargo-metadata, use the json file at this path
+
         --no-all-features
             Don't use --all-features
             

--- a/tests/snapshots/test_cli__markdown-help.snap
+++ b/tests/snapshots/test_cli__markdown-help.snap
@@ -40,6 +40,9 @@ Print version information
 #### `--manifest-path <PATH>`
 Path to Cargo.toml
 
+#### `--with-metadata <WITH_METADATA>`
+Instead of running cargo-metadata, use the json file at this path
+
 #### `--no-all-features`
 Don't use --all-features
 

--- a/tests/snapshots/test_cli__markdown-help.snap
+++ b/tests/snapshots/test_cli__markdown-help.snap
@@ -79,7 +79,7 @@ Instead of stderr, write logs to this file (only used after successful CLI parsi
 The format of the output
 
 \[default: human]  
-\[possible values: human, json]  
+\[possible values: human, json, json-full]  
 
 #### `--diff-cache <DIFF_CACHE>`
 Use the following path as the diff-cache
@@ -147,6 +147,7 @@ graph
 * [record-violation](#cargo-vet-record-violation): Declare that some versions of a package violate certain audit criteria
 * [fmt](#cargo-vet-fmt): Reformat all of vet's files (in case you hand-edited them)
 * [fetch-imports](#cargo-vet-fetch-imports): Explicitly fetch the imports (foreign audit files)
+* [aggregate](#cargo-vet-aggregate): Fetch and merge audits from multiple sources into a single `audits.toml` file
 * [dump-graph](#cargo-vet-dump-graph): Print the cargo build graph as understood by `cargo vet`
 * [gc](#cargo-vet-gc): Clean up old packages from the vet cache
 * [help](#cargo-vet-help): Print this message or the help of the given subcommand(s)
@@ -646,6 +647,29 @@ top of vet.
 ```
 cargo vet fetch-imports [OPTIONS]
 ```
+
+### OPTIONS
+#### `-h, --help`
+Print help information
+
+### GLOBAL OPTIONS
+This subcommand accepts all the [global options](#global-options)
+
+<br><br><br>
+## cargo vet aggregate
+Fetch and merge audits from multiple sources into a single `audits.toml` file.
+
+Will fetch the audits from each URL in the provided file, combining them into a single file. Custom
+criteria will be merged by-name, and must have identical descriptions in each source audit file.
+
+### USAGE
+```
+cargo vet aggregate [OPTIONS] <SOURCES>
+```
+
+### ARGS
+#### `<SOURCES>`
+Path to a file containing a list of URLs to aggregate the audits from
 
 ### OPTIONS
 #### `-h, --help`

--- a/tests/snapshots/test_cli__short-help.snap
+++ b/tests/snapshots/test_cli__short-help.snap
@@ -50,7 +50,7 @@ GLOBAL OPTIONS:
             Instead of stderr, write logs to this file (only used after successful CLI parsing)
 
         --output-format <OUTPUT_FORMAT>
-            The format of the output [default: human] [possible values: human, json]
+            The format of the output [default: human] [possible values: human, json, json-full]
 
         --diff-cache <DIFF_CACHE>
             Use the following path as the diff-cache
@@ -70,6 +70,8 @@ SUBCOMMANDS:
     record-violation    Declare that some versions of a package violate certain audit criteria
     fmt                 Reformat all of vet's files (in case you hand-edited them)
     fetch-imports       Explicitly fetch the imports (foreign audit files)
+    aggregate           Fetch and merge audits from multiple sources into a single `audits.toml`
+                            file
     dump-graph          Print the cargo build graph as understood by `cargo vet`
     gc                  Clean up old packages from the vet cache
     help                Print this message or the help of the given subcommand(s)

--- a/tests/snapshots/test_cli__short-help.snap
+++ b/tests/snapshots/test_cli__short-help.snap
@@ -19,6 +19,9 @@ GLOBAL OPTIONS:
         --manifest-path <PATH>
             Path to Cargo.toml
 
+        --with-metadata <WITH_METADATA>
+            Instead of running cargo-metadata, use the json file at this path
+
         --no-all-features
             Don't use --all-features
 

--- a/tests/snapshots/test_cli__test-project-json.snap
+++ b/tests/snapshots/test_cli__test-project-json.snap
@@ -4,6 +4,7 @@ expression: format_outputs(&output)
 ---
 stdout:
 {
+  "context": null,
   "conclusion": "success",
   "vetted_fully": [
     {

--- a/tests/snapshots/test_cli__test-project-suggest-json.snap
+++ b/tests/snapshots/test_cli__test-project-suggest-json.snap
@@ -4,696 +4,2169 @@ expression: format_outputs(&output)
 ---
 stdout:
 {
+  "context": null,
   "conclusion": "fail (vetting)",
   "failures": [
     {
-      "missing_criteria": [
-        "safe-to-deploy"
-      ],
       "name": "bumpalo",
-      "version": "3.9.1"
-    },
-    {
+      "version": "3.9.1",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "bytes",
-      "version": "1.1.0"
-    },
-    {
+      "version": "1.1.0",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "cc",
-      "version": "1.0.73"
-    },
-    {
+      "version": "1.0.73",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "cfg-if",
-      "version": "1.0.0"
-    },
-    {
+      "version": "1.0.0",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "core-foundation",
-      "version": "0.9.3"
-    },
-    {
+      "version": "0.9.3",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "core-foundation-sys",
-      "version": "0.8.3"
-    },
-    {
+      "version": "0.8.3",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "encoding_rs",
-      "version": "0.8.31"
-    },
-    {
+      "version": "0.8.31",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "fastrand",
-      "version": "1.7.0"
-    },
-    {
+      "version": "1.7.0",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "fnv",
-      "version": "1.0.7"
-    },
-    {
+      "version": "1.0.7",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "foreign-types",
-      "version": "0.3.2"
-    },
-    {
+      "version": "0.3.2",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "foreign-types-shared",
-      "version": "0.1.1"
-    },
-    {
+      "version": "0.1.1",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "form_urlencoded",
-      "version": "1.0.1"
-    },
-    {
+      "version": "1.0.1",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "futures-channel",
-      "version": "0.3.21"
-    },
-    {
+      "version": "0.3.21",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "futures-core",
-      "version": "0.3.21"
-    },
-    {
+      "version": "0.3.21",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "futures-sink",
-      "version": "0.3.21"
-    },
-    {
+      "version": "0.3.21",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "futures-task",
-      "version": "0.3.21"
-    },
-    {
+      "version": "0.3.21",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "futures-util",
-      "version": "0.3.21"
-    },
-    {
+      "version": "0.3.21",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "h2",
-      "version": "0.3.13"
-    },
-    {
+      "version": "0.3.13",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
-      "name": "hashbrown",
-      "version": "0.11.2"
+      ]
     },
     {
+      "name": "hashbrown",
+      "version": "0.11.2",
+      "missing_criteria": [
+        "safe-to-deploy"
+      ]
+    },
+    {
+      "name": "hermit-abi",
+      "version": "0.1.19",
       "missing_criteria": [
         "safe-to-run"
-      ],
-      "name": "hermit-abi",
-      "version": "0.1.19"
+      ]
     },
     {
-      "missing_criteria": [
-        "safe-to-deploy"
-      ],
       "name": "http",
-      "version": "0.2.6"
-    },
-    {
+      "version": "0.2.6",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "http-body",
-      "version": "0.4.4"
-    },
-    {
+      "version": "0.4.4",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "httparse",
-      "version": "1.7.0"
-    },
-    {
+      "version": "1.7.0",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "httpdate",
-      "version": "1.0.2"
-    },
-    {
+      "version": "1.0.2",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "hyper",
-      "version": "0.14.18"
-    },
-    {
+      "version": "0.14.18",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "hyper-tls",
-      "version": "0.5.0"
-    },
-    {
+      "version": "0.5.0",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "idna",
-      "version": "0.2.3"
-    },
-    {
+      "version": "0.2.3",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "indexmap",
-      "version": "1.8.1"
-    },
-    {
+      "version": "1.8.1",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "instant",
-      "version": "0.1.12"
-    },
-    {
+      "version": "0.1.12",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "ipnet",
-      "version": "2.4.0"
-    },
-    {
+      "version": "2.4.0",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "itoa",
-      "version": "1.0.1"
-    },
-    {
+      "version": "1.0.1",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "js-sys",
-      "version": "0.3.57"
-    },
-    {
+      "version": "0.3.57",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "lazy_static",
-      "version": "1.4.0"
-    },
-    {
+      "version": "1.4.0",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "libc",
-      "version": "0.2.123"
-    },
-    {
+      "version": "0.2.123",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "log",
-      "version": "0.4.16"
-    },
-    {
+      "version": "0.4.16",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "matches",
-      "version": "0.1.9"
-    },
-    {
+      "version": "0.1.9",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "memchr",
-      "version": "2.4.1"
-    },
-    {
+      "version": "2.4.1",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "mime",
-      "version": "0.3.16"
-    },
-    {
+      "version": "0.3.16",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "mio",
-      "version": "0.8.2"
-    },
-    {
+      "version": "0.8.2",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "miow",
-      "version": "0.3.7"
-    },
-    {
+      "version": "0.3.7",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "native-tls",
-      "version": "0.2.10"
-    },
-    {
+      "version": "0.2.10",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "ntapi",
-      "version": "0.3.7"
-    },
-    {
+      "version": "0.3.7",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "once_cell",
-      "version": "1.10.0"
-    },
-    {
+      "version": "1.10.0",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "openssl",
-      "version": "0.10.38"
-    },
-    {
+      "version": "0.10.38",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "openssl-probe",
-      "version": "0.1.5"
-    },
-    {
+      "version": "0.1.5",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "openssl-sys",
-      "version": "0.9.72"
-    },
-    {
+      "version": "0.9.72",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "os_str_bytes",
-      "version": "6.0.0"
-    },
-    {
+      "version": "6.0.0",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "percent-encoding",
-      "version": "2.1.0"
-    },
-    {
+      "version": "2.1.0",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "pin-project-lite",
-      "version": "0.2.8"
-    },
-    {
+      "version": "0.2.8",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "pin-utils",
-      "version": "0.1.0"
-    },
-    {
+      "version": "0.1.0",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "pkg-config",
-      "version": "0.3.25"
-    },
-    {
+      "version": "0.3.25",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "proc-macro2",
-      "version": "1.0.37"
-    },
-    {
+      "version": "1.0.37",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "quote",
-      "version": "1.0.18"
-    },
-    {
+      "version": "1.0.18",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "redox_syscall",
-      "version": "0.2.13"
-    },
-    {
+      "version": "0.2.13",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "remove_dir_all",
-      "version": "0.5.3"
-    },
-    {
+      "version": "0.5.3",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "reqwest",
-      "version": "0.11.10"
-    },
-    {
+      "version": "0.11.10",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "ryu",
-      "version": "1.0.9"
-    },
-    {
+      "version": "1.0.9",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "schannel",
-      "version": "0.1.19"
-    },
-    {
+      "version": "0.1.19",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "security-framework",
-      "version": "2.6.1"
-    },
-    {
+      "version": "2.6.1",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "security-framework-sys",
-      "version": "2.6.1"
-    },
-    {
+      "version": "2.6.1",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "serde",
-      "version": "1.0.136"
-    },
-    {
+      "version": "1.0.136",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "serde_json",
-      "version": "1.0.79"
-    },
-    {
+      "version": "1.0.79",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "serde_urlencoded",
-      "version": "0.7.1"
-    },
-    {
+      "version": "0.7.1",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "slab",
-      "version": "0.4.6"
-    },
-    {
+      "version": "0.4.6",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "socket2",
-      "version": "0.4.4"
-    },
-    {
+      "version": "0.4.4",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "syn",
-      "version": "1.0.91"
-    },
-    {
+      "version": "1.0.91",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "tempfile",
-      "version": "3.3.0"
-    },
-    {
+      "version": "3.3.0",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "termcolor",
-      "version": "1.1.3"
-    },
-    {
+      "version": "1.1.3",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "textwrap",
-      "version": "0.15.0"
-    },
-    {
+      "version": "0.15.0",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "tinyvec",
-      "version": "1.5.1"
-    },
-    {
+      "version": "1.5.1",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "tinyvec_macros",
-      "version": "0.1.0"
-    },
-    {
+      "version": "0.1.0",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "tokio",
-      "version": "1.17.0"
-    },
-    {
+      "version": "1.17.0",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "tokio-native-tls",
-      "version": "0.3.0"
-    },
-    {
+      "version": "0.3.0",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "tokio-util",
-      "version": "0.7.1"
-    },
-    {
+      "version": "0.7.1",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "tower-service",
-      "version": "0.3.1"
-    },
-    {
+      "version": "0.3.1",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "tracing",
-      "version": "0.1.33"
-    },
-    {
+      "version": "0.1.33",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "tracing-attributes",
-      "version": "0.1.20"
-    },
-    {
+      "version": "0.1.20",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "tracing-core",
-      "version": "0.1.25"
-    },
-    {
+      "version": "0.1.25",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "try-lock",
-      "version": "0.2.3"
-    },
-    {
+      "version": "0.2.3",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "unicode-bidi",
-      "version": "0.3.7"
-    },
-    {
+      "version": "0.3.7",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "unicode-normalization",
-      "version": "0.1.19"
-    },
-    {
+      "version": "0.1.19",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "unicode-xid",
-      "version": "0.2.2"
-    },
-    {
+      "version": "0.2.2",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "url",
-      "version": "2.2.2"
-    },
-    {
+      "version": "2.2.2",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "vcpkg",
-      "version": "0.2.15"
-    },
-    {
+      "version": "0.2.15",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "want",
-      "version": "0.3.0"
-    },
-    {
+      "version": "0.3.0",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "wasi",
-      "version": "0.11.0+wasi-snapshot-preview1"
-    },
-    {
+      "version": "0.11.0+wasi-snapshot-preview1",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "wasm-bindgen",
-      "version": "0.2.80"
-    },
-    {
+      "version": "0.2.80",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "wasm-bindgen-backend",
-      "version": "0.2.80"
-    },
-    {
+      "version": "0.2.80",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "wasm-bindgen-futures",
-      "version": "0.4.30"
-    },
-    {
+      "version": "0.4.30",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "wasm-bindgen-macro",
-      "version": "0.2.80"
-    },
-    {
+      "version": "0.2.80",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "wasm-bindgen-macro-support",
-      "version": "0.2.80"
-    },
-    {
+      "version": "0.2.80",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "wasm-bindgen-shared",
-      "version": "0.2.80"
-    },
-    {
+      "version": "0.2.80",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "web-sys",
-      "version": "0.3.57"
-    },
-    {
+      "version": "0.3.57",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "winapi",
-      "version": "0.3.9"
-    },
-    {
+      "version": "0.3.9",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "winapi-i686-pc-windows-gnu",
-      "version": "0.4.0"
-    },
-    {
+      "version": "0.4.0",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "winapi-util",
-      "version": "0.1.5"
-    },
-    {
+      "version": "0.1.5",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "winapi-x86_64-pc-windows-gnu",
-      "version": "0.4.0"
-    },
-    {
+      "version": "0.4.0",
       "missing_criteria": [
         "safe-to-deploy"
-      ],
+      ]
+    },
+    {
       "name": "winreg",
-      "version": "0.10.1"
+      "version": "0.10.1",
+      "missing_criteria": [
+        "safe-to-deploy"
+      ]
     }
   ],
   "suggest": {
+    "suggestions": [
+      {
+        "name": "hermit-abi",
+        "notable_parents": "atty",
+        "suggested_criteria": [
+          "safe-to-run"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.1.19",
+          "diffstat": {
+            "raw": " 11 files changed, 938 insertions(+)\n",
+            "count": 938
+          }
+        }
+      },
+      {
+        "name": "termcolor",
+        "notable_parents": "clap",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "1.1.3",
+          "diffstat": {
+            "raw": " 12 files changed, 2585 insertions(+)\n",
+            "count": 2585
+          }
+        }
+      },
+      {
+        "name": "os_str_bytes",
+        "notable_parents": "clap",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "6.0.0",
+          "diffstat": {
+            "raw": " 23 files changed, 2918 insertions(+)\n",
+            "count": 2918
+          }
+        }
+      },
+      {
+        "name": "textwrap",
+        "notable_parents": "clap",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.15.0",
+          "diffstat": {
+            "raw": " 18 files changed, 6165 insertions(+)\n",
+            "count": 6165
+          }
+        }
+      },
+      {
+        "name": "indexmap",
+        "notable_parents": "h2, clap",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "1.8.1",
+          "diffstat": {
+            "raw": " 33 files changed, 9452 insertions(+)\n",
+            "count": 9452
+          }
+        }
+      },
+      {
+        "name": "reqwest",
+        "notable_parents": "test-project",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.11.10",
+          "diffstat": {
+            "raw": " 63 files changed, 21663 insertions(+)\n",
+            "count": 21663
+          }
+        }
+      },
+      {
+        "name": "serde_json",
+        "notable_parents": "reqwest, test-project",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "1.0.79",
+          "diffstat": {
+            "raw": " 88 files changed, 22855 insertions(+)\n",
+            "count": 22855
+          }
+        }
+      },
+      {
+        "name": "tokio",
+        "notable_parents": "h2, hyper, reqwest, and 4 others",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "1.17.0",
+          "diffstat": {
+            "raw": " 405 files changed, 91278 insertions(+)\n",
+            "count": 91278
+          }
+        }
+      },
+      {
+        "name": "libc",
+        "notable_parents": "mio, atty, tokio, openssl, and 8 others",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.2.123",
+          "diffstat": {
+            "raw": " 217 files changed, 94067 insertions(+)\n",
+            "count": 94067
+          }
+        }
+      },
+      {
+        "name": "winapi",
+        "notable_parents": "mio, atty, miow, ntapi, and 7 others",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.3.9",
+          "diffstat": {
+            "raw": " 412 files changed, 181329 insertions(+)\n",
+            "count": 181329
+          }
+        }
+      },
+      {
+        "name": "tinyvec_macros",
+        "notable_parents": "tinyvec",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.1.0",
+          "diffstat": {
+            "raw": " 7 files changed, 87 insertions(+)\n",
+            "count": 87
+          }
+        }
+      },
+      {
+        "name": "matches",
+        "notable_parents": "url, idna, form_urlencoded",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.1.9",
+          "diffstat": {
+            "raw": " 7 files changed, 211 insertions(+)\n",
+            "count": 211
+          }
+        }
+      },
+      {
+        "name": "foreign-types-shared",
+        "notable_parents": "foreign-types",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.1.1",
+          "diffstat": {
+            "raw": " 6 files changed, 303 insertions(+)\n",
+            "count": 303
+          }
+        }
+      },
+      {
+        "name": "try-lock",
+        "notable_parents": "want",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.2.3",
+          "diffstat": {
+            "raw": " 8 files changed, 386 insertions(+)\n",
+            "count": 386
+          }
+        }
+      },
+      {
+        "name": "openssl-probe",
+        "notable_parents": "native-tls",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.1.5",
+          "diffstat": {
+            "raw": " 12 files changed, 456 insertions(+)\n",
+            "count": 456
+          }
+        }
+      },
+      {
+        "name": "tower-service",
+        "notable_parents": "hyper",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.3.1",
+          "diffstat": {
+            "raw": " 8 files changed, 507 insertions(+)\n",
+            "count": 507
+          }
+        }
+      },
+      {
+        "name": "wasm-bindgen-shared",
+        "notable_parents": "wasm-bindgen-backend, wasm-bindgen-macro-support",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.2.80",
+          "diffstat": {
+            "raw": " 8 files changed, 516 insertions(+)\n",
+            "count": 516
+          }
+        }
+      },
+      {
+        "name": "pin-utils",
+        "notable_parents": "futures-util",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.1.0",
+          "diffstat": {
+            "raw": " 15 files changed, 544 insertions(+)\n",
+            "count": 544
+          }
+        }
+      },
+      {
+        "name": "futures-sink",
+        "notable_parents": "h2, tokio-util",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.3.21",
+          "diffstat": {
+            "raw": " 8 files changed, 551 insertions(+)\n",
+            "count": 551
+          }
+        }
+      },
+      {
+        "name": "foreign-types",
+        "notable_parents": "openssl",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.3.2",
+          "diffstat": {
+            "raw": " 7 files changed, 584 insertions(+)\n",
+            "count": 584
+          }
+        }
+      },
+      {
+        "name": "cfg-if",
+        "notable_parents": "log, instant, openssl, and 5 others",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "1.0.0",
+          "diffstat": {
+            "raw": " 11 files changed, 588 insertions(+)\n",
+            "count": 588
+          }
+        }
+      },
+      {
+        "name": "remove_dir_all",
+        "notable_parents": "tempfile",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.5.3",
+          "diffstat": {
+            "raw": " 9 files changed, 598 insertions(+)\n",
+            "count": 598
+          }
+        }
+      },
+      {
+        "name": "instant",
+        "notable_parents": "fastrand",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.1.12",
+          "diffstat": {
+            "raw": " 14 files changed, 678 insertions(+)\n",
+            "count": 678
+          }
+        }
+      },
+      {
+        "name": "form_urlencoded",
+        "notable_parents": "url, serde_urlencoded",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "1.0.1",
+          "diffstat": {
+            "raw": " 7 files changed, 695 insertions(+)\n",
+            "count": 695
+          }
+        }
+      },
+      {
+        "name": "want",
+        "notable_parents": "hyper",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.3.0",
+          "diffstat": {
+            "raw": " 9 files changed, 703 insertions(+)\n",
+            "count": 703
+          }
+        }
+      },
+      {
+        "name": "percent-encoding",
+        "notable_parents": "url, reqwest, form_urlencoded",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "2.1.0",
+          "diffstat": {
+            "raw": " 7 files changed, 708 insertions(+)\n",
+            "count": 708
+          }
+        }
+      },
+      {
+        "name": "fnv",
+        "notable_parents": "h2, http",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "1.0.7",
+          "diffstat": {
+            "raw": " 10 files changed, 736 insertions(+)\n",
+            "count": 736
+          }
+        }
+      },
+      {
+        "name": "itoa",
+        "notable_parents": "http, hyper, serde_json, serde_urlencoded",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "1.0.1",
+          "diffstat": {
+            "raw": " 15 files changed, 796 insertions(+)\n",
+            "count": 796
+          }
+        }
+      },
+      {
+        "name": "lazy_static",
+        "notable_parents": "reqwest, schannel, and 3 others",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "1.4.0",
+          "diffstat": {
+            "raw": " 13 files changed, 882 insertions(+)\n",
+            "count": 882
+          }
+        }
+      },
+      {
+        "name": "httpdate",
+        "notable_parents": "hyper",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "1.0.2",
+          "diffstat": {
+            "raw": " 12 files changed, 1001 insertions(+)\n",
+            "count": 1001
+          }
+        }
+      },
+      {
+        "name": "winapi-util",
+        "notable_parents": "termcolor",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.1.5",
+          "diffstat": {
+            "raw": " 15 files changed, 1101 insertions(+)\n",
+            "count": 1101
+          }
+        }
+      },
+      {
+        "name": "winapi-i686-pc-windows-gnu",
+        "notable_parents": "winapi",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.4.0",
+          "diffstat": {
+            "raw": " 1392 files changed, 1133 insertions(+)\n",
+            "count": 1133
+          }
+        }
+      },
+      {
+        "name": "winapi-x86_64-pc-windows-gnu",
+        "notable_parents": "winapi",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.4.0",
+          "diffstat": {
+            "raw": " 1421 files changed, 1168 insertions(+)\n",
+            "count": 1168
+          }
+        }
+      },
+      {
+        "name": "futures-core",
+        "notable_parents": "h2, hyper, reqwest, and 3 others",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.3.21",
+          "diffstat": {
+            "raw": " 16 files changed, 1182 insertions(+)\n",
+            "count": 1182
+          }
+        }
+      },
+      {
+        "name": "futures-task",
+        "notable_parents": "futures-util",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.3.21",
+          "diffstat": {
+            "raw": " 16 files changed, 1187 insertions(+)\n",
+            "count": 1187
+          }
+        }
+      },
+      {
+        "name": "http-body",
+        "notable_parents": "hyper, reqwest",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.4.4",
+          "diffstat": {
+            "raw": " 19 files changed, 1262 insertions(+)\n",
+            "count": 1262
+          }
+        }
+      },
+      {
+        "name": "wasm-bindgen-macro",
+        "notable_parents": "wasm-bindgen",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.2.80",
+          "diffstat": {
+            "raw": " 46 files changed, 1275 insertions(+)\n",
+            "count": 1275
+          }
+        }
+      },
+      {
+        "name": "hyper-tls",
+        "notable_parents": "reqwest",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.5.0",
+          "diffstat": {
+            "raw": " 14 files changed, 1301 insertions(+)\n",
+            "count": 1301
+          }
+        }
+      },
+      {
+        "name": "wasm-bindgen-futures",
+        "notable_parents": "reqwest",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.4.30",
+          "diffstat": {
+            "raw": " 13 files changed, 1304 insertions(+)\n",
+            "count": 1304
+          }
+        }
+      },
+      {
+        "name": "fastrand",
+        "notable_parents": "tempfile",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "1.7.0",
+          "diffstat": {
+            "raw": " 12 files changed, 1375 insertions(+)\n",
+            "count": 1375
+          }
+        }
+      },
+      {
+        "name": "mime",
+        "notable_parents": "reqwest",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.3.16",
+          "diffstat": {
+            "raw": " 15 files changed, 1721 insertions(+)\n",
+            "count": 1721
+          }
+        }
+      },
+      {
+        "name": "pkg-config",
+        "notable_parents": "openssl-sys",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.3.25",
+          "diffstat": {
+            "raw": " 16 files changed, 1754 insertions(+)\n",
+            "count": 1754
+          }
+        }
+      },
+      {
+        "name": "tokio-native-tls",
+        "notable_parents": "reqwest, hyper-tls",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.3.0",
+          "diffstat": {
+            "raw": " 19 files changed, 1804 insertions(+)\n",
+            "count": 1804
+          }
+        }
+      },
+      {
+        "name": "wasm-bindgen-macro-support",
+        "notable_parents": "wasm-bindgen-macro",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.2.80",
+          "diffstat": {
+            "raw": " 7 files changed, 1966 insertions(+)\n",
+            "count": 1966
+          }
+        }
+      },
+      {
+        "name": "core-foundation-sys",
+        "notable_parents": "core-foundation, and 2 others",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.8.3",
+          "diffstat": {
+            "raw": " 28 files changed, 1971 insertions(+)\n",
+            "count": 1971
+          }
+        }
+      },
+      {
+        "name": "security-framework-sys",
+        "notable_parents": "native-tls, security-framework",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "2.6.1",
+          "diffstat": {
+            "raw": " 29 files changed, 2023 insertions(+)\n",
+            "count": 2023
+          }
+        }
+      },
+      {
+        "name": "unicode-xid",
+        "notable_parents": "syn, proc-macro2",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.2.2",
+          "diffstat": {
+            "raw": " 14 files changed, 2050 insertions(+)\n",
+            "count": 2050
+          }
+        }
+      },
+      {
+        "name": "serde_urlencoded",
+        "notable_parents": "reqwest",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.7.1",
+          "diffstat": {
+            "raw": " 19 files changed, 2127 insertions(+)\n",
+            "count": 2127
+          }
+        }
+      },
+      {
+        "name": "slab",
+        "notable_parents": "h2",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.4.6",
+          "diffstat": {
+            "raw": " 11 files changed, 2622 insertions(+)\n",
+            "count": 2622
+          }
+        }
+      },
+      {
+        "name": "wasm-bindgen-backend",
+        "notable_parents": "wasm-bindgen-macro-support",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.2.80",
+          "diffstat": {
+            "raw": " 11 files changed, 3019 insertions(+)\n",
+            "count": 3019
+          }
+        }
+      },
+      {
+        "name": "miow",
+        "notable_parents": "mio",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.3.7",
+          "diffstat": {
+            "raw": " 16 files changed, 3135 insertions(+)\n",
+            "count": 3135
+          }
+        }
+      },
+      {
+        "name": "wasi",
+        "notable_parents": "mio",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.11.0+wasi-snapshot-preview1",
+          "diffstat": {
+            "raw": " 17 files changed, 3309 insertions(+)\n",
+            "count": 3309
+          }
+        }
+      },
+      {
+        "name": "unicode-bidi",
+        "notable_parents": "idna",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.3.7",
+          "diffstat": {
+            "raw": " 23 files changed, 3398 insertions(+)\n",
+            "count": 3398
+          }
+        }
+      },
+      {
+        "name": "quote",
+        "notable_parents": "syn, and 4 others",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "1.0.18",
+          "diffstat": {
+            "raw": " 35 files changed, 3845 insertions(+)\n",
+            "count": 3845
+          }
+        }
+      },
+      {
+        "name": "redox_syscall",
+        "notable_parents": "tempfile",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.2.13",
+          "diffstat": {
+            "raw": " 32 files changed, 3897 insertions(+)\n",
+            "count": 3897
+          }
+        }
+      },
+      {
+        "name": "core-foundation",
+        "notable_parents": "security-framework",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.9.3",
+          "diffstat": {
+            "raw": " 28 files changed, 3960 insertions(+)\n",
+            "count": 3960
+          }
+        }
+      },
+      {
+        "name": "tracing-attributes",
+        "notable_parents": "tracing",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.1.20",
+          "diffstat": {
+            "raw": " 20 files changed, 3964 insertions(+)\n",
+            "count": 3964
+          }
+        }
+      },
+      {
+        "name": "ipnet",
+        "notable_parents": "reqwest",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "2.4.0",
+          "diffstat": {
+            "raw": " 15 files changed, 3980 insertions(+)\n",
+            "count": 3980
+          }
+        }
+      },
+      {
+        "name": "futures-channel",
+        "notable_parents": "hyper",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.3.21",
+          "diffstat": {
+            "raw": " 20 files changed, 3999 insertions(+)\n",
+            "count": 3999
+          }
+        }
+      },
+      {
+        "name": "tempfile",
+        "notable_parents": "native-tls",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "3.3.0",
+          "diffstat": {
+            "raw": " 24 files changed, 4066 insertions(+)\n",
+            "count": 4066
+          }
+        }
+      },
+      {
+        "name": "native-tls",
+        "notable_parents": "reqwest, hyper-tls, tokio-native-tls",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.2.10",
+          "diffstat": {
+            "raw": " 21 files changed, 4089 insertions(+)\n",
+            "count": 4089
+          }
+        }
+      },
+      {
+        "name": "once_cell",
+        "notable_parents": "openssl",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "1.10.0",
+          "diffstat": {
+            "raw": " 24 files changed, 4140 insertions(+)\n",
+            "count": 4140
+          }
+        }
+      },
+      {
+        "name": "winreg",
+        "notable_parents": "reqwest",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.10.1",
+          "diffstat": {
+            "raw": " 29 files changed, 4276 insertions(+)\n",
+            "count": 4276
+          }
+        }
+      },
+      {
+        "name": "ryu",
+        "notable_parents": "serde_json, serde_urlencoded",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "1.0.9",
+          "diffstat": {
+            "raw": " 37 files changed, 4531 insertions(+)\n",
+            "count": 4531
+          }
+        }
+      },
+      {
+        "name": "schannel",
+        "notable_parents": "native-tls",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.1.19",
+          "diffstat": {
+            "raw": " 34 files changed, 4607 insertions(+)\n",
+            "count": 4607
+          }
+        }
+      },
+      {
+        "name": "log",
+        "notable_parents": "mio, want, reqwest, and 2 others",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.4.16",
+          "diffstat": {
+            "raw": " 21 files changed, 5632 insertions(+)\n",
+            "count": 5632
+          }
+        }
+      },
+      {
+        "name": "proc-macro2",
+        "notable_parents": "syn, quote, and 3 others",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "1.0.37",
+          "diffstat": {
+            "raw": " 22 files changed, 5702 insertions(+)\n",
+            "count": 5702
+          }
+        }
+      },
+      {
+        "name": "socket2",
+        "notable_parents": "hyper, tokio",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.4.4",
+          "diffstat": {
+            "raw": " 13 files changed, 6018 insertions(+)\n",
+            "count": 6018
+          }
+        }
+      },
+      {
+        "name": "pin-project-lite",
+        "notable_parents": "hyper, tokio, reqwest, and 4 others",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.2.8",
+          "diffstat": {
+            "raw": " 72 files changed, 6107 insertions(+)\n",
+            "count": 6107
+          }
+        }
+      },
+      {
+        "name": "tracing-core",
+        "notable_parents": "tracing",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.1.25",
+          "diffstat": {
+            "raw": " 28 files changed, 6163 insertions(+)\n",
+            "count": 6163
+          }
+        }
+      },
+      {
+        "name": "cc",
+        "notable_parents": "openssl-sys",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "1.0.73",
+          "diffstat": {
+            "raw": " 22 files changed, 6671 insertions(+)\n",
+            "count": 6671
+          }
+        }
+      },
+      {
+        "name": "httparse",
+        "notable_parents": "hyper",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "1.7.0",
+          "diffstat": {
+            "raw": " 20 files changed, 7265 insertions(+)\n",
+            "count": 7265
+          }
+        }
+      },
+      {
+        "name": "memchr",
+        "notable_parents": "tokio, os_str_bytes",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "2.4.1",
+          "diffstat": {
+            "raw": " 48 files changed, 8718 insertions(+)\n",
+            "count": 8718
+          }
+        }
+      },
+      {
+        "name": "bytes",
+        "notable_parents": "h2, http, hyper, tokio, and 4 others",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "1.1.0",
+          "diffstat": {
+            "raw": " 45 files changed, 9213 insertions(+)\n",
+            "count": 9213
+          }
+        }
+      },
+      {
+        "name": "openssl-sys",
+        "notable_parents": "openssl, native-tls",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.9.72",
+          "diffstat": {
+            "raw": " 48 files changed, 9484 insertions(+)\n",
+            "count": 9484
+          }
+        }
+      },
+      {
+        "name": "security-framework",
+        "notable_parents": "native-tls",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "2.6.1",
+          "diffstat": {
+            "raw": " 45 files changed, 9776 insertions(+)\n",
+            "count": 9776
+          }
+        }
+      },
+      {
+        "name": "bumpalo",
+        "notable_parents": "wasm-bindgen-backend",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "3.9.1",
+          "diffstat": {
+            "raw": " 19 files changed, 10106 insertions(+)\n",
+            "count": 10106
+          }
+        }
+      },
+      {
+        "name": "tracing",
+        "notable_parents": "h2, hyper, tokio-util",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.1.33",
+          "diffstat": {
+            "raw": " 34 files changed, 10957 insertions(+)\n",
+            "count": 10957
+          }
+        }
+      },
+      {
+        "name": "mio",
+        "notable_parents": "tokio",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.8.2",
+          "diffstat": {
+            "raw": " 65 files changed, 11882 insertions(+)\n",
+            "count": 11882
+          }
+        }
+      },
+      {
+        "name": "js-sys",
+        "notable_parents": "reqwest, web-sys, wasm-bindgen-futures",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.3.57",
+          "diffstat": {
+            "raw": " 63 files changed, 12875 insertions(+)\n",
+            "count": 12875
+          }
+        }
+      },
+      {
+        "name": "tokio-util",
+        "notable_parents": "h2",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.7.1",
+          "diffstat": {
+            "raw": " 67 files changed, 13877 insertions(+)\n",
+            "count": 13877
+          }
+        }
+      },
+      {
+        "name": "hashbrown",
+        "notable_parents": "indexmap",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.11.2",
+          "diffstat": {
+            "raw": " 33 files changed, 14609 insertions(+)\n",
+            "count": 14609
+          }
+        }
+      },
+      {
+        "name": "serde",
+        "notable_parents": "reqwest, serde_json, serde_urlencoded",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "1.0.136",
+          "diffstat": {
+            "raw": " 29 files changed, 16148 insertions(+)\n",
+            "count": 16148
+          }
+        }
+      },
+      {
+        "name": "url",
+        "notable_parents": "reqwest",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "2.2.2",
+          "diffstat": {
+            "raw": " 17 files changed, 16350 insertions(+)\n",
+            "count": 16350
+          }
+        }
+      },
+      {
+        "name": "tinyvec",
+        "notable_parents": "unicode-normalization",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "1.5.1",
+          "diffstat": {
+            "raw": " 27 files changed, 16758 insertions(+)\n",
+            "count": 16758
+          }
+        }
+      },
+      {
+        "name": "http",
+        "notable_parents": "h2, hyper, reqwest, http-body",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.2.6",
+          "diffstat": {
+            "raw": " 41 files changed, 16826 insertions(+)\n",
+            "count": 16826
+          }
+        }
+      },
+      {
+        "name": "wasm-bindgen",
+        "notable_parents": "js-sys, reqwest, web-sys, wasm-bindgen-futures",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.2.80",
+          "diffstat": {
+            "raw": " 243 files changed, 20978 insertions(+)\n",
+            "count": 20978
+          }
+        }
+      },
+      {
+        "name": "ntapi",
+        "notable_parents": "mio",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.3.7",
+          "diffstat": {
+            "raw": " 44 files changed, 21234 insertions(+)\n",
+            "count": 21234
+          }
+        }
+      },
+      {
+        "name": "futures-util",
+        "notable_parents": "h2, hyper, reqwest",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.3.21",
+          "diffstat": {
+            "raw": " 187 files changed, 25074 insertions(+)\n",
+            "count": 25074
+          }
+        }
+      },
+      {
+        "name": "hyper",
+        "notable_parents": "reqwest, hyper-tls",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.14.18",
+          "diffstat": {
+            "raw": " 72 files changed, 25617 insertions(+)\n",
+            "count": 25617
+          }
+        }
+      },
+      {
+        "name": "h2",
+        "notable_parents": "hyper, reqwest",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.3.13",
+          "diffstat": {
+            "raw": " 66 files changed, 26066 insertions(+)\n",
+            "count": 26066
+          }
+        }
+      },
+      {
+        "name": "syn",
+        "notable_parents": "tracing-attributes, and 2 others",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": "1.0.0",
+          "to": "1.0.91",
+          "diffstat": {
+            "raw": " 93 files changed, 21776 insertions(+), 6701 deletions(-)\n",
+            "count": 28477
+          }
+        }
+      },
+      {
+        "name": "unicode-normalization",
+        "notable_parents": "idna",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.1.19",
+          "diffstat": {
+            "raw": " 26 files changed, 28628 insertions(+)\n",
+            "count": 28628
+          }
+        }
+      },
+      {
+        "name": "openssl",
+        "notable_parents": "native-tls",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.10.38",
+          "diffstat": {
+            "raw": " 85 files changed, 28634 insertions(+)\n",
+            "count": 28634
+          }
+        }
+      },
+      {
+        "name": "idna",
+        "notable_parents": "url",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.2.3",
+          "diffstat": {
+            "raw": " 19 files changed, 32538 insertions(+)\n",
+            "count": 32538
+          }
+        }
+      },
+      {
+        "name": "vcpkg",
+        "notable_parents": "openssl-sys",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.2.15",
+          "diffstat": {
+            "raw": " 834 files changed, 42648 insertions(+)\n",
+            "count": 42648
+          }
+        }
+      },
+      {
+        "name": "web-sys",
+        "notable_parents": "reqwest, wasm-bindgen-futures",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.3.57",
+          "diffstat": {
+            "raw": " 2203 files changed, 197014 insertions(+)\n",
+            "count": 197014
+          }
+        }
+      },
+      {
+        "name": "encoding_rs",
+        "notable_parents": "reqwest",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.8.31",
+          "diffstat": {
+            "raw": " 104 files changed, 507252 insertions(+)\n",
+            "count": 507252
+          }
+        }
+      }
+    ],
     "suggest_by_criteria": {
       "safe-to-deploy": [
         {
@@ -703,12 +2176,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 2585,
-              "raw": " 12 files changed, 2585 insertions(+)\n"
-            },
             "from": null,
-            "to": "1.1.3"
+            "to": "1.1.3",
+            "diffstat": {
+              "raw": " 12 files changed, 2585 insertions(+)\n",
+              "count": 2585
+            }
           }
         },
         {
@@ -718,12 +2191,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 2918,
-              "raw": " 23 files changed, 2918 insertions(+)\n"
-            },
             "from": null,
-            "to": "6.0.0"
+            "to": "6.0.0",
+            "diffstat": {
+              "raw": " 23 files changed, 2918 insertions(+)\n",
+              "count": 2918
+            }
           }
         },
         {
@@ -733,12 +2206,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 6165,
-              "raw": " 18 files changed, 6165 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.15.0"
+            "to": "0.15.0",
+            "diffstat": {
+              "raw": " 18 files changed, 6165 insertions(+)\n",
+              "count": 6165
+            }
           }
         },
         {
@@ -748,12 +2221,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 9452,
-              "raw": " 33 files changed, 9452 insertions(+)\n"
-            },
             "from": null,
-            "to": "1.8.1"
+            "to": "1.8.1",
+            "diffstat": {
+              "raw": " 33 files changed, 9452 insertions(+)\n",
+              "count": 9452
+            }
           }
         },
         {
@@ -763,12 +2236,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 21663,
-              "raw": " 63 files changed, 21663 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.11.10"
+            "to": "0.11.10",
+            "diffstat": {
+              "raw": " 63 files changed, 21663 insertions(+)\n",
+              "count": 21663
+            }
           }
         },
         {
@@ -778,12 +2251,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 22855,
-              "raw": " 88 files changed, 22855 insertions(+)\n"
-            },
             "from": null,
-            "to": "1.0.79"
+            "to": "1.0.79",
+            "diffstat": {
+              "raw": " 88 files changed, 22855 insertions(+)\n",
+              "count": 22855
+            }
           }
         },
         {
@@ -793,12 +2266,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 91278,
-              "raw": " 405 files changed, 91278 insertions(+)\n"
-            },
             "from": null,
-            "to": "1.17.0"
+            "to": "1.17.0",
+            "diffstat": {
+              "raw": " 405 files changed, 91278 insertions(+)\n",
+              "count": 91278
+            }
           }
         },
         {
@@ -808,12 +2281,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 94067,
-              "raw": " 217 files changed, 94067 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.2.123"
+            "to": "0.2.123",
+            "diffstat": {
+              "raw": " 217 files changed, 94067 insertions(+)\n",
+              "count": 94067
+            }
           }
         },
         {
@@ -823,12 +2296,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 181329,
-              "raw": " 412 files changed, 181329 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.3.9"
+            "to": "0.3.9",
+            "diffstat": {
+              "raw": " 412 files changed, 181329 insertions(+)\n",
+              "count": 181329
+            }
           }
         },
         {
@@ -838,12 +2311,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 87,
-              "raw": " 7 files changed, 87 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.1.0"
+            "to": "0.1.0",
+            "diffstat": {
+              "raw": " 7 files changed, 87 insertions(+)\n",
+              "count": 87
+            }
           }
         },
         {
@@ -853,12 +2326,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 211,
-              "raw": " 7 files changed, 211 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.1.9"
+            "to": "0.1.9",
+            "diffstat": {
+              "raw": " 7 files changed, 211 insertions(+)\n",
+              "count": 211
+            }
           }
         },
         {
@@ -868,12 +2341,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 303,
-              "raw": " 6 files changed, 303 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.1.1"
+            "to": "0.1.1",
+            "diffstat": {
+              "raw": " 6 files changed, 303 insertions(+)\n",
+              "count": 303
+            }
           }
         },
         {
@@ -883,12 +2356,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 386,
-              "raw": " 8 files changed, 386 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.2.3"
+            "to": "0.2.3",
+            "diffstat": {
+              "raw": " 8 files changed, 386 insertions(+)\n",
+              "count": 386
+            }
           }
         },
         {
@@ -898,12 +2371,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 456,
-              "raw": " 12 files changed, 456 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.1.5"
+            "to": "0.1.5",
+            "diffstat": {
+              "raw": " 12 files changed, 456 insertions(+)\n",
+              "count": 456
+            }
           }
         },
         {
@@ -913,12 +2386,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 507,
-              "raw": " 8 files changed, 507 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.3.1"
+            "to": "0.3.1",
+            "diffstat": {
+              "raw": " 8 files changed, 507 insertions(+)\n",
+              "count": 507
+            }
           }
         },
         {
@@ -928,12 +2401,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 516,
-              "raw": " 8 files changed, 516 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.2.80"
+            "to": "0.2.80",
+            "diffstat": {
+              "raw": " 8 files changed, 516 insertions(+)\n",
+              "count": 516
+            }
           }
         },
         {
@@ -943,12 +2416,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 544,
-              "raw": " 15 files changed, 544 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.1.0"
+            "to": "0.1.0",
+            "diffstat": {
+              "raw": " 15 files changed, 544 insertions(+)\n",
+              "count": 544
+            }
           }
         },
         {
@@ -958,12 +2431,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 551,
-              "raw": " 8 files changed, 551 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.3.21"
+            "to": "0.3.21",
+            "diffstat": {
+              "raw": " 8 files changed, 551 insertions(+)\n",
+              "count": 551
+            }
           }
         },
         {
@@ -973,12 +2446,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 584,
-              "raw": " 7 files changed, 584 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.3.2"
+            "to": "0.3.2",
+            "diffstat": {
+              "raw": " 7 files changed, 584 insertions(+)\n",
+              "count": 584
+            }
           }
         },
         {
@@ -988,12 +2461,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 588,
-              "raw": " 11 files changed, 588 insertions(+)\n"
-            },
             "from": null,
-            "to": "1.0.0"
+            "to": "1.0.0",
+            "diffstat": {
+              "raw": " 11 files changed, 588 insertions(+)\n",
+              "count": 588
+            }
           }
         },
         {
@@ -1003,12 +2476,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 598,
-              "raw": " 9 files changed, 598 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.5.3"
+            "to": "0.5.3",
+            "diffstat": {
+              "raw": " 9 files changed, 598 insertions(+)\n",
+              "count": 598
+            }
           }
         },
         {
@@ -1018,12 +2491,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 678,
-              "raw": " 14 files changed, 678 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.1.12"
+            "to": "0.1.12",
+            "diffstat": {
+              "raw": " 14 files changed, 678 insertions(+)\n",
+              "count": 678
+            }
           }
         },
         {
@@ -1033,12 +2506,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 695,
-              "raw": " 7 files changed, 695 insertions(+)\n"
-            },
             "from": null,
-            "to": "1.0.1"
+            "to": "1.0.1",
+            "diffstat": {
+              "raw": " 7 files changed, 695 insertions(+)\n",
+              "count": 695
+            }
           }
         },
         {
@@ -1048,12 +2521,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 703,
-              "raw": " 9 files changed, 703 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.3.0"
+            "to": "0.3.0",
+            "diffstat": {
+              "raw": " 9 files changed, 703 insertions(+)\n",
+              "count": 703
+            }
           }
         },
         {
@@ -1063,12 +2536,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 708,
-              "raw": " 7 files changed, 708 insertions(+)\n"
-            },
             "from": null,
-            "to": "2.1.0"
+            "to": "2.1.0",
+            "diffstat": {
+              "raw": " 7 files changed, 708 insertions(+)\n",
+              "count": 708
+            }
           }
         },
         {
@@ -1078,12 +2551,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 736,
-              "raw": " 10 files changed, 736 insertions(+)\n"
-            },
             "from": null,
-            "to": "1.0.7"
+            "to": "1.0.7",
+            "diffstat": {
+              "raw": " 10 files changed, 736 insertions(+)\n",
+              "count": 736
+            }
           }
         },
         {
@@ -1093,12 +2566,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 796,
-              "raw": " 15 files changed, 796 insertions(+)\n"
-            },
             "from": null,
-            "to": "1.0.1"
+            "to": "1.0.1",
+            "diffstat": {
+              "raw": " 15 files changed, 796 insertions(+)\n",
+              "count": 796
+            }
           }
         },
         {
@@ -1108,12 +2581,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 882,
-              "raw": " 13 files changed, 882 insertions(+)\n"
-            },
             "from": null,
-            "to": "1.4.0"
+            "to": "1.4.0",
+            "diffstat": {
+              "raw": " 13 files changed, 882 insertions(+)\n",
+              "count": 882
+            }
           }
         },
         {
@@ -1123,12 +2596,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 1001,
-              "raw": " 12 files changed, 1001 insertions(+)\n"
-            },
             "from": null,
-            "to": "1.0.2"
+            "to": "1.0.2",
+            "diffstat": {
+              "raw": " 12 files changed, 1001 insertions(+)\n",
+              "count": 1001
+            }
           }
         },
         {
@@ -1138,12 +2611,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 1101,
-              "raw": " 15 files changed, 1101 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.1.5"
+            "to": "0.1.5",
+            "diffstat": {
+              "raw": " 15 files changed, 1101 insertions(+)\n",
+              "count": 1101
+            }
           }
         },
         {
@@ -1153,12 +2626,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 1133,
-              "raw": " 1392 files changed, 1133 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.4.0"
+            "to": "0.4.0",
+            "diffstat": {
+              "raw": " 1392 files changed, 1133 insertions(+)\n",
+              "count": 1133
+            }
           }
         },
         {
@@ -1168,12 +2641,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 1168,
-              "raw": " 1421 files changed, 1168 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.4.0"
+            "to": "0.4.0",
+            "diffstat": {
+              "raw": " 1421 files changed, 1168 insertions(+)\n",
+              "count": 1168
+            }
           }
         },
         {
@@ -1183,12 +2656,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 1182,
-              "raw": " 16 files changed, 1182 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.3.21"
+            "to": "0.3.21",
+            "diffstat": {
+              "raw": " 16 files changed, 1182 insertions(+)\n",
+              "count": 1182
+            }
           }
         },
         {
@@ -1198,12 +2671,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 1187,
-              "raw": " 16 files changed, 1187 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.3.21"
+            "to": "0.3.21",
+            "diffstat": {
+              "raw": " 16 files changed, 1187 insertions(+)\n",
+              "count": 1187
+            }
           }
         },
         {
@@ -1213,12 +2686,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 1262,
-              "raw": " 19 files changed, 1262 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.4.4"
+            "to": "0.4.4",
+            "diffstat": {
+              "raw": " 19 files changed, 1262 insertions(+)\n",
+              "count": 1262
+            }
           }
         },
         {
@@ -1228,12 +2701,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 1275,
-              "raw": " 46 files changed, 1275 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.2.80"
+            "to": "0.2.80",
+            "diffstat": {
+              "raw": " 46 files changed, 1275 insertions(+)\n",
+              "count": 1275
+            }
           }
         },
         {
@@ -1243,12 +2716,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 1301,
-              "raw": " 14 files changed, 1301 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.5.0"
+            "to": "0.5.0",
+            "diffstat": {
+              "raw": " 14 files changed, 1301 insertions(+)\n",
+              "count": 1301
+            }
           }
         },
         {
@@ -1258,12 +2731,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 1304,
-              "raw": " 13 files changed, 1304 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.4.30"
+            "to": "0.4.30",
+            "diffstat": {
+              "raw": " 13 files changed, 1304 insertions(+)\n",
+              "count": 1304
+            }
           }
         },
         {
@@ -1273,12 +2746,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 1375,
-              "raw": " 12 files changed, 1375 insertions(+)\n"
-            },
             "from": null,
-            "to": "1.7.0"
+            "to": "1.7.0",
+            "diffstat": {
+              "raw": " 12 files changed, 1375 insertions(+)\n",
+              "count": 1375
+            }
           }
         },
         {
@@ -1288,12 +2761,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 1721,
-              "raw": " 15 files changed, 1721 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.3.16"
+            "to": "0.3.16",
+            "diffstat": {
+              "raw": " 15 files changed, 1721 insertions(+)\n",
+              "count": 1721
+            }
           }
         },
         {
@@ -1303,12 +2776,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 1754,
-              "raw": " 16 files changed, 1754 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.3.25"
+            "to": "0.3.25",
+            "diffstat": {
+              "raw": " 16 files changed, 1754 insertions(+)\n",
+              "count": 1754
+            }
           }
         },
         {
@@ -1318,12 +2791,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 1804,
-              "raw": " 19 files changed, 1804 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.3.0"
+            "to": "0.3.0",
+            "diffstat": {
+              "raw": " 19 files changed, 1804 insertions(+)\n",
+              "count": 1804
+            }
           }
         },
         {
@@ -1333,12 +2806,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 1966,
-              "raw": " 7 files changed, 1966 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.2.80"
+            "to": "0.2.80",
+            "diffstat": {
+              "raw": " 7 files changed, 1966 insertions(+)\n",
+              "count": 1966
+            }
           }
         },
         {
@@ -1348,12 +2821,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 1971,
-              "raw": " 28 files changed, 1971 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.8.3"
+            "to": "0.8.3",
+            "diffstat": {
+              "raw": " 28 files changed, 1971 insertions(+)\n",
+              "count": 1971
+            }
           }
         },
         {
@@ -1363,12 +2836,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 2023,
-              "raw": " 29 files changed, 2023 insertions(+)\n"
-            },
             "from": null,
-            "to": "2.6.1"
+            "to": "2.6.1",
+            "diffstat": {
+              "raw": " 29 files changed, 2023 insertions(+)\n",
+              "count": 2023
+            }
           }
         },
         {
@@ -1378,12 +2851,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 2050,
-              "raw": " 14 files changed, 2050 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.2.2"
+            "to": "0.2.2",
+            "diffstat": {
+              "raw": " 14 files changed, 2050 insertions(+)\n",
+              "count": 2050
+            }
           }
         },
         {
@@ -1393,12 +2866,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 2127,
-              "raw": " 19 files changed, 2127 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.7.1"
+            "to": "0.7.1",
+            "diffstat": {
+              "raw": " 19 files changed, 2127 insertions(+)\n",
+              "count": 2127
+            }
           }
         },
         {
@@ -1408,12 +2881,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 2622,
-              "raw": " 11 files changed, 2622 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.4.6"
+            "to": "0.4.6",
+            "diffstat": {
+              "raw": " 11 files changed, 2622 insertions(+)\n",
+              "count": 2622
+            }
           }
         },
         {
@@ -1423,12 +2896,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 3019,
-              "raw": " 11 files changed, 3019 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.2.80"
+            "to": "0.2.80",
+            "diffstat": {
+              "raw": " 11 files changed, 3019 insertions(+)\n",
+              "count": 3019
+            }
           }
         },
         {
@@ -1438,12 +2911,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 3135,
-              "raw": " 16 files changed, 3135 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.3.7"
+            "to": "0.3.7",
+            "diffstat": {
+              "raw": " 16 files changed, 3135 insertions(+)\n",
+              "count": 3135
+            }
           }
         },
         {
@@ -1453,12 +2926,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 3309,
-              "raw": " 17 files changed, 3309 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.11.0+wasi-snapshot-preview1"
+            "to": "0.11.0+wasi-snapshot-preview1",
+            "diffstat": {
+              "raw": " 17 files changed, 3309 insertions(+)\n",
+              "count": 3309
+            }
           }
         },
         {
@@ -1468,12 +2941,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 3398,
-              "raw": " 23 files changed, 3398 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.3.7"
+            "to": "0.3.7",
+            "diffstat": {
+              "raw": " 23 files changed, 3398 insertions(+)\n",
+              "count": 3398
+            }
           }
         },
         {
@@ -1483,12 +2956,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 3845,
-              "raw": " 35 files changed, 3845 insertions(+)\n"
-            },
             "from": null,
-            "to": "1.0.18"
+            "to": "1.0.18",
+            "diffstat": {
+              "raw": " 35 files changed, 3845 insertions(+)\n",
+              "count": 3845
+            }
           }
         },
         {
@@ -1498,12 +2971,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 3897,
-              "raw": " 32 files changed, 3897 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.2.13"
+            "to": "0.2.13",
+            "diffstat": {
+              "raw": " 32 files changed, 3897 insertions(+)\n",
+              "count": 3897
+            }
           }
         },
         {
@@ -1513,12 +2986,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 3960,
-              "raw": " 28 files changed, 3960 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.9.3"
+            "to": "0.9.3",
+            "diffstat": {
+              "raw": " 28 files changed, 3960 insertions(+)\n",
+              "count": 3960
+            }
           }
         },
         {
@@ -1528,12 +3001,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 3964,
-              "raw": " 20 files changed, 3964 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.1.20"
+            "to": "0.1.20",
+            "diffstat": {
+              "raw": " 20 files changed, 3964 insertions(+)\n",
+              "count": 3964
+            }
           }
         },
         {
@@ -1543,12 +3016,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 3980,
-              "raw": " 15 files changed, 3980 insertions(+)\n"
-            },
             "from": null,
-            "to": "2.4.0"
+            "to": "2.4.0",
+            "diffstat": {
+              "raw": " 15 files changed, 3980 insertions(+)\n",
+              "count": 3980
+            }
           }
         },
         {
@@ -1558,12 +3031,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 3999,
-              "raw": " 20 files changed, 3999 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.3.21"
+            "to": "0.3.21",
+            "diffstat": {
+              "raw": " 20 files changed, 3999 insertions(+)\n",
+              "count": 3999
+            }
           }
         },
         {
@@ -1573,12 +3046,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 4066,
-              "raw": " 24 files changed, 4066 insertions(+)\n"
-            },
             "from": null,
-            "to": "3.3.0"
+            "to": "3.3.0",
+            "diffstat": {
+              "raw": " 24 files changed, 4066 insertions(+)\n",
+              "count": 4066
+            }
           }
         },
         {
@@ -1588,12 +3061,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 4089,
-              "raw": " 21 files changed, 4089 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.2.10"
+            "to": "0.2.10",
+            "diffstat": {
+              "raw": " 21 files changed, 4089 insertions(+)\n",
+              "count": 4089
+            }
           }
         },
         {
@@ -1603,12 +3076,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 4140,
-              "raw": " 24 files changed, 4140 insertions(+)\n"
-            },
             "from": null,
-            "to": "1.10.0"
+            "to": "1.10.0",
+            "diffstat": {
+              "raw": " 24 files changed, 4140 insertions(+)\n",
+              "count": 4140
+            }
           }
         },
         {
@@ -1618,12 +3091,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 4276,
-              "raw": " 29 files changed, 4276 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.10.1"
+            "to": "0.10.1",
+            "diffstat": {
+              "raw": " 29 files changed, 4276 insertions(+)\n",
+              "count": 4276
+            }
           }
         },
         {
@@ -1633,12 +3106,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 4531,
-              "raw": " 37 files changed, 4531 insertions(+)\n"
-            },
             "from": null,
-            "to": "1.0.9"
+            "to": "1.0.9",
+            "diffstat": {
+              "raw": " 37 files changed, 4531 insertions(+)\n",
+              "count": 4531
+            }
           }
         },
         {
@@ -1648,12 +3121,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 4607,
-              "raw": " 34 files changed, 4607 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.1.19"
+            "to": "0.1.19",
+            "diffstat": {
+              "raw": " 34 files changed, 4607 insertions(+)\n",
+              "count": 4607
+            }
           }
         },
         {
@@ -1663,12 +3136,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 5632,
-              "raw": " 21 files changed, 5632 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.4.16"
+            "to": "0.4.16",
+            "diffstat": {
+              "raw": " 21 files changed, 5632 insertions(+)\n",
+              "count": 5632
+            }
           }
         },
         {
@@ -1678,12 +3151,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 5702,
-              "raw": " 22 files changed, 5702 insertions(+)\n"
-            },
             "from": null,
-            "to": "1.0.37"
+            "to": "1.0.37",
+            "diffstat": {
+              "raw": " 22 files changed, 5702 insertions(+)\n",
+              "count": 5702
+            }
           }
         },
         {
@@ -1693,12 +3166,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 6018,
-              "raw": " 13 files changed, 6018 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.4.4"
+            "to": "0.4.4",
+            "diffstat": {
+              "raw": " 13 files changed, 6018 insertions(+)\n",
+              "count": 6018
+            }
           }
         },
         {
@@ -1708,12 +3181,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 6107,
-              "raw": " 72 files changed, 6107 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.2.8"
+            "to": "0.2.8",
+            "diffstat": {
+              "raw": " 72 files changed, 6107 insertions(+)\n",
+              "count": 6107
+            }
           }
         },
         {
@@ -1723,12 +3196,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 6163,
-              "raw": " 28 files changed, 6163 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.1.25"
+            "to": "0.1.25",
+            "diffstat": {
+              "raw": " 28 files changed, 6163 insertions(+)\n",
+              "count": 6163
+            }
           }
         },
         {
@@ -1738,12 +3211,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 6671,
-              "raw": " 22 files changed, 6671 insertions(+)\n"
-            },
             "from": null,
-            "to": "1.0.73"
+            "to": "1.0.73",
+            "diffstat": {
+              "raw": " 22 files changed, 6671 insertions(+)\n",
+              "count": 6671
+            }
           }
         },
         {
@@ -1753,12 +3226,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 7265,
-              "raw": " 20 files changed, 7265 insertions(+)\n"
-            },
             "from": null,
-            "to": "1.7.0"
+            "to": "1.7.0",
+            "diffstat": {
+              "raw": " 20 files changed, 7265 insertions(+)\n",
+              "count": 7265
+            }
           }
         },
         {
@@ -1768,12 +3241,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 8718,
-              "raw": " 48 files changed, 8718 insertions(+)\n"
-            },
             "from": null,
-            "to": "2.4.1"
+            "to": "2.4.1",
+            "diffstat": {
+              "raw": " 48 files changed, 8718 insertions(+)\n",
+              "count": 8718
+            }
           }
         },
         {
@@ -1783,12 +3256,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 9213,
-              "raw": " 45 files changed, 9213 insertions(+)\n"
-            },
             "from": null,
-            "to": "1.1.0"
+            "to": "1.1.0",
+            "diffstat": {
+              "raw": " 45 files changed, 9213 insertions(+)\n",
+              "count": 9213
+            }
           }
         },
         {
@@ -1798,12 +3271,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 9484,
-              "raw": " 48 files changed, 9484 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.9.72"
+            "to": "0.9.72",
+            "diffstat": {
+              "raw": " 48 files changed, 9484 insertions(+)\n",
+              "count": 9484
+            }
           }
         },
         {
@@ -1813,12 +3286,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 9776,
-              "raw": " 45 files changed, 9776 insertions(+)\n"
-            },
             "from": null,
-            "to": "2.6.1"
+            "to": "2.6.1",
+            "diffstat": {
+              "raw": " 45 files changed, 9776 insertions(+)\n",
+              "count": 9776
+            }
           }
         },
         {
@@ -1828,12 +3301,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 10106,
-              "raw": " 19 files changed, 10106 insertions(+)\n"
-            },
             "from": null,
-            "to": "3.9.1"
+            "to": "3.9.1",
+            "diffstat": {
+              "raw": " 19 files changed, 10106 insertions(+)\n",
+              "count": 10106
+            }
           }
         },
         {
@@ -1843,12 +3316,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 10957,
-              "raw": " 34 files changed, 10957 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.1.33"
+            "to": "0.1.33",
+            "diffstat": {
+              "raw": " 34 files changed, 10957 insertions(+)\n",
+              "count": 10957
+            }
           }
         },
         {
@@ -1858,12 +3331,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 11882,
-              "raw": " 65 files changed, 11882 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.8.2"
+            "to": "0.8.2",
+            "diffstat": {
+              "raw": " 65 files changed, 11882 insertions(+)\n",
+              "count": 11882
+            }
           }
         },
         {
@@ -1873,12 +3346,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 12875,
-              "raw": " 63 files changed, 12875 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.3.57"
+            "to": "0.3.57",
+            "diffstat": {
+              "raw": " 63 files changed, 12875 insertions(+)\n",
+              "count": 12875
+            }
           }
         },
         {
@@ -1888,12 +3361,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 13877,
-              "raw": " 67 files changed, 13877 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.7.1"
+            "to": "0.7.1",
+            "diffstat": {
+              "raw": " 67 files changed, 13877 insertions(+)\n",
+              "count": 13877
+            }
           }
         },
         {
@@ -1903,12 +3376,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 14609,
-              "raw": " 33 files changed, 14609 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.11.2"
+            "to": "0.11.2",
+            "diffstat": {
+              "raw": " 33 files changed, 14609 insertions(+)\n",
+              "count": 14609
+            }
           }
         },
         {
@@ -1918,12 +3391,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 16148,
-              "raw": " 29 files changed, 16148 insertions(+)\n"
-            },
             "from": null,
-            "to": "1.0.136"
+            "to": "1.0.136",
+            "diffstat": {
+              "raw": " 29 files changed, 16148 insertions(+)\n",
+              "count": 16148
+            }
           }
         },
         {
@@ -1933,12 +3406,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 16350,
-              "raw": " 17 files changed, 16350 insertions(+)\n"
-            },
             "from": null,
-            "to": "2.2.2"
+            "to": "2.2.2",
+            "diffstat": {
+              "raw": " 17 files changed, 16350 insertions(+)\n",
+              "count": 16350
+            }
           }
         },
         {
@@ -1948,12 +3421,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 16758,
-              "raw": " 27 files changed, 16758 insertions(+)\n"
-            },
             "from": null,
-            "to": "1.5.1"
+            "to": "1.5.1",
+            "diffstat": {
+              "raw": " 27 files changed, 16758 insertions(+)\n",
+              "count": 16758
+            }
           }
         },
         {
@@ -1963,12 +3436,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 16826,
-              "raw": " 41 files changed, 16826 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.2.6"
+            "to": "0.2.6",
+            "diffstat": {
+              "raw": " 41 files changed, 16826 insertions(+)\n",
+              "count": 16826
+            }
           }
         },
         {
@@ -1978,12 +3451,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 20978,
-              "raw": " 243 files changed, 20978 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.2.80"
+            "to": "0.2.80",
+            "diffstat": {
+              "raw": " 243 files changed, 20978 insertions(+)\n",
+              "count": 20978
+            }
           }
         },
         {
@@ -1993,12 +3466,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 21234,
-              "raw": " 44 files changed, 21234 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.3.7"
+            "to": "0.3.7",
+            "diffstat": {
+              "raw": " 44 files changed, 21234 insertions(+)\n",
+              "count": 21234
+            }
           }
         },
         {
@@ -2008,12 +3481,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 25074,
-              "raw": " 187 files changed, 25074 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.3.21"
+            "to": "0.3.21",
+            "diffstat": {
+              "raw": " 187 files changed, 25074 insertions(+)\n",
+              "count": 25074
+            }
           }
         },
         {
@@ -2023,12 +3496,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 25617,
-              "raw": " 72 files changed, 25617 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.14.18"
+            "to": "0.14.18",
+            "diffstat": {
+              "raw": " 72 files changed, 25617 insertions(+)\n",
+              "count": 25617
+            }
           }
         },
         {
@@ -2038,12 +3511,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 26066,
-              "raw": " 66 files changed, 26066 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.3.13"
+            "to": "0.3.13",
+            "diffstat": {
+              "raw": " 66 files changed, 26066 insertions(+)\n",
+              "count": 26066
+            }
           }
         },
         {
@@ -2053,12 +3526,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 28477,
-              "raw": " 93 files changed, 21776 insertions(+), 6701 deletions(-)\n"
-            },
             "from": "1.0.0",
-            "to": "1.0.91"
+            "to": "1.0.91",
+            "diffstat": {
+              "raw": " 93 files changed, 21776 insertions(+), 6701 deletions(-)\n",
+              "count": 28477
+            }
           }
         },
         {
@@ -2068,12 +3541,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 28628,
-              "raw": " 26 files changed, 28628 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.1.19"
+            "to": "0.1.19",
+            "diffstat": {
+              "raw": " 26 files changed, 28628 insertions(+)\n",
+              "count": 28628
+            }
           }
         },
         {
@@ -2083,12 +3556,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 28634,
-              "raw": " 85 files changed, 28634 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.10.38"
+            "to": "0.10.38",
+            "diffstat": {
+              "raw": " 85 files changed, 28634 insertions(+)\n",
+              "count": 28634
+            }
           }
         },
         {
@@ -2098,12 +3571,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 32538,
-              "raw": " 19 files changed, 32538 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.2.3"
+            "to": "0.2.3",
+            "diffstat": {
+              "raw": " 19 files changed, 32538 insertions(+)\n",
+              "count": 32538
+            }
           }
         },
         {
@@ -2113,12 +3586,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 42648,
-              "raw": " 834 files changed, 42648 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.2.15"
+            "to": "0.2.15",
+            "diffstat": {
+              "raw": " 834 files changed, 42648 insertions(+)\n",
+              "count": 42648
+            }
           }
         },
         {
@@ -2128,12 +3601,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 197014,
-              "raw": " 2203 files changed, 197014 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.3.57"
+            "to": "0.3.57",
+            "diffstat": {
+              "raw": " 2203 files changed, 197014 insertions(+)\n",
+              "count": 197014
+            }
           }
         },
         {
@@ -2143,12 +3616,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 507252,
-              "raw": " 104 files changed, 507252 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.8.31"
+            "to": "0.8.31",
+            "diffstat": {
+              "raw": " 104 files changed, 507252 insertions(+)\n",
+              "count": 507252
+            }
           }
         }
       ],
@@ -2160,1488 +3633,16 @@ stdout:
             "safe-to-run"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 938,
-              "raw": " 11 files changed, 938 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.1.19"
+            "to": "0.1.19",
+            "diffstat": {
+              "raw": " 11 files changed, 938 insertions(+)\n",
+              "count": 938
+            }
           }
         }
       ]
     },
-    "suggestions": [
-      {
-        "name": "hermit-abi",
-        "notable_parents": "atty",
-        "suggested_criteria": [
-          "safe-to-run"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 938,
-            "raw": " 11 files changed, 938 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.1.19"
-        }
-      },
-      {
-        "name": "termcolor",
-        "notable_parents": "clap",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 2585,
-            "raw": " 12 files changed, 2585 insertions(+)\n"
-          },
-          "from": null,
-          "to": "1.1.3"
-        }
-      },
-      {
-        "name": "os_str_bytes",
-        "notable_parents": "clap",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 2918,
-            "raw": " 23 files changed, 2918 insertions(+)\n"
-          },
-          "from": null,
-          "to": "6.0.0"
-        }
-      },
-      {
-        "name": "textwrap",
-        "notable_parents": "clap",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 6165,
-            "raw": " 18 files changed, 6165 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.15.0"
-        }
-      },
-      {
-        "name": "indexmap",
-        "notable_parents": "h2, clap",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 9452,
-            "raw": " 33 files changed, 9452 insertions(+)\n"
-          },
-          "from": null,
-          "to": "1.8.1"
-        }
-      },
-      {
-        "name": "reqwest",
-        "notable_parents": "test-project",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 21663,
-            "raw": " 63 files changed, 21663 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.11.10"
-        }
-      },
-      {
-        "name": "serde_json",
-        "notable_parents": "reqwest, test-project",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 22855,
-            "raw": " 88 files changed, 22855 insertions(+)\n"
-          },
-          "from": null,
-          "to": "1.0.79"
-        }
-      },
-      {
-        "name": "tokio",
-        "notable_parents": "h2, hyper, reqwest, and 4 others",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 91278,
-            "raw": " 405 files changed, 91278 insertions(+)\n"
-          },
-          "from": null,
-          "to": "1.17.0"
-        }
-      },
-      {
-        "name": "libc",
-        "notable_parents": "mio, atty, tokio, openssl, and 8 others",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 94067,
-            "raw": " 217 files changed, 94067 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.2.123"
-        }
-      },
-      {
-        "name": "winapi",
-        "notable_parents": "mio, atty, miow, ntapi, and 7 others",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 181329,
-            "raw": " 412 files changed, 181329 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.3.9"
-        }
-      },
-      {
-        "name": "tinyvec_macros",
-        "notable_parents": "tinyvec",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 87,
-            "raw": " 7 files changed, 87 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.1.0"
-        }
-      },
-      {
-        "name": "matches",
-        "notable_parents": "url, idna, form_urlencoded",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 211,
-            "raw": " 7 files changed, 211 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.1.9"
-        }
-      },
-      {
-        "name": "foreign-types-shared",
-        "notable_parents": "foreign-types",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 303,
-            "raw": " 6 files changed, 303 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.1.1"
-        }
-      },
-      {
-        "name": "try-lock",
-        "notable_parents": "want",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 386,
-            "raw": " 8 files changed, 386 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.2.3"
-        }
-      },
-      {
-        "name": "openssl-probe",
-        "notable_parents": "native-tls",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 456,
-            "raw": " 12 files changed, 456 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.1.5"
-        }
-      },
-      {
-        "name": "tower-service",
-        "notable_parents": "hyper",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 507,
-            "raw": " 8 files changed, 507 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.3.1"
-        }
-      },
-      {
-        "name": "wasm-bindgen-shared",
-        "notable_parents": "wasm-bindgen-backend, wasm-bindgen-macro-support",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 516,
-            "raw": " 8 files changed, 516 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.2.80"
-        }
-      },
-      {
-        "name": "pin-utils",
-        "notable_parents": "futures-util",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 544,
-            "raw": " 15 files changed, 544 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.1.0"
-        }
-      },
-      {
-        "name": "futures-sink",
-        "notable_parents": "h2, tokio-util",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 551,
-            "raw": " 8 files changed, 551 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.3.21"
-        }
-      },
-      {
-        "name": "foreign-types",
-        "notable_parents": "openssl",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 584,
-            "raw": " 7 files changed, 584 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.3.2"
-        }
-      },
-      {
-        "name": "cfg-if",
-        "notable_parents": "log, instant, openssl, and 5 others",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 588,
-            "raw": " 11 files changed, 588 insertions(+)\n"
-          },
-          "from": null,
-          "to": "1.0.0"
-        }
-      },
-      {
-        "name": "remove_dir_all",
-        "notable_parents": "tempfile",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 598,
-            "raw": " 9 files changed, 598 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.5.3"
-        }
-      },
-      {
-        "name": "instant",
-        "notable_parents": "fastrand",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 678,
-            "raw": " 14 files changed, 678 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.1.12"
-        }
-      },
-      {
-        "name": "form_urlencoded",
-        "notable_parents": "url, serde_urlencoded",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 695,
-            "raw": " 7 files changed, 695 insertions(+)\n"
-          },
-          "from": null,
-          "to": "1.0.1"
-        }
-      },
-      {
-        "name": "want",
-        "notable_parents": "hyper",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 703,
-            "raw": " 9 files changed, 703 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.3.0"
-        }
-      },
-      {
-        "name": "percent-encoding",
-        "notable_parents": "url, reqwest, form_urlencoded",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 708,
-            "raw": " 7 files changed, 708 insertions(+)\n"
-          },
-          "from": null,
-          "to": "2.1.0"
-        }
-      },
-      {
-        "name": "fnv",
-        "notable_parents": "h2, http",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 736,
-            "raw": " 10 files changed, 736 insertions(+)\n"
-          },
-          "from": null,
-          "to": "1.0.7"
-        }
-      },
-      {
-        "name": "itoa",
-        "notable_parents": "http, hyper, serde_json, serde_urlencoded",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 796,
-            "raw": " 15 files changed, 796 insertions(+)\n"
-          },
-          "from": null,
-          "to": "1.0.1"
-        }
-      },
-      {
-        "name": "lazy_static",
-        "notable_parents": "reqwest, schannel, and 3 others",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 882,
-            "raw": " 13 files changed, 882 insertions(+)\n"
-          },
-          "from": null,
-          "to": "1.4.0"
-        }
-      },
-      {
-        "name": "httpdate",
-        "notable_parents": "hyper",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 1001,
-            "raw": " 12 files changed, 1001 insertions(+)\n"
-          },
-          "from": null,
-          "to": "1.0.2"
-        }
-      },
-      {
-        "name": "winapi-util",
-        "notable_parents": "termcolor",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 1101,
-            "raw": " 15 files changed, 1101 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.1.5"
-        }
-      },
-      {
-        "name": "winapi-i686-pc-windows-gnu",
-        "notable_parents": "winapi",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 1133,
-            "raw": " 1392 files changed, 1133 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.4.0"
-        }
-      },
-      {
-        "name": "winapi-x86_64-pc-windows-gnu",
-        "notable_parents": "winapi",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 1168,
-            "raw": " 1421 files changed, 1168 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.4.0"
-        }
-      },
-      {
-        "name": "futures-core",
-        "notable_parents": "h2, hyper, reqwest, and 3 others",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 1182,
-            "raw": " 16 files changed, 1182 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.3.21"
-        }
-      },
-      {
-        "name": "futures-task",
-        "notable_parents": "futures-util",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 1187,
-            "raw": " 16 files changed, 1187 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.3.21"
-        }
-      },
-      {
-        "name": "http-body",
-        "notable_parents": "hyper, reqwest",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 1262,
-            "raw": " 19 files changed, 1262 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.4.4"
-        }
-      },
-      {
-        "name": "wasm-bindgen-macro",
-        "notable_parents": "wasm-bindgen",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 1275,
-            "raw": " 46 files changed, 1275 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.2.80"
-        }
-      },
-      {
-        "name": "hyper-tls",
-        "notable_parents": "reqwest",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 1301,
-            "raw": " 14 files changed, 1301 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.5.0"
-        }
-      },
-      {
-        "name": "wasm-bindgen-futures",
-        "notable_parents": "reqwest",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 1304,
-            "raw": " 13 files changed, 1304 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.4.30"
-        }
-      },
-      {
-        "name": "fastrand",
-        "notable_parents": "tempfile",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 1375,
-            "raw": " 12 files changed, 1375 insertions(+)\n"
-          },
-          "from": null,
-          "to": "1.7.0"
-        }
-      },
-      {
-        "name": "mime",
-        "notable_parents": "reqwest",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 1721,
-            "raw": " 15 files changed, 1721 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.3.16"
-        }
-      },
-      {
-        "name": "pkg-config",
-        "notable_parents": "openssl-sys",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 1754,
-            "raw": " 16 files changed, 1754 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.3.25"
-        }
-      },
-      {
-        "name": "tokio-native-tls",
-        "notable_parents": "reqwest, hyper-tls",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 1804,
-            "raw": " 19 files changed, 1804 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.3.0"
-        }
-      },
-      {
-        "name": "wasm-bindgen-macro-support",
-        "notable_parents": "wasm-bindgen-macro",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 1966,
-            "raw": " 7 files changed, 1966 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.2.80"
-        }
-      },
-      {
-        "name": "core-foundation-sys",
-        "notable_parents": "core-foundation, and 2 others",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 1971,
-            "raw": " 28 files changed, 1971 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.8.3"
-        }
-      },
-      {
-        "name": "security-framework-sys",
-        "notable_parents": "native-tls, security-framework",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 2023,
-            "raw": " 29 files changed, 2023 insertions(+)\n"
-          },
-          "from": null,
-          "to": "2.6.1"
-        }
-      },
-      {
-        "name": "unicode-xid",
-        "notable_parents": "syn, proc-macro2",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 2050,
-            "raw": " 14 files changed, 2050 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.2.2"
-        }
-      },
-      {
-        "name": "serde_urlencoded",
-        "notable_parents": "reqwest",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 2127,
-            "raw": " 19 files changed, 2127 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.7.1"
-        }
-      },
-      {
-        "name": "slab",
-        "notable_parents": "h2",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 2622,
-            "raw": " 11 files changed, 2622 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.4.6"
-        }
-      },
-      {
-        "name": "wasm-bindgen-backend",
-        "notable_parents": "wasm-bindgen-macro-support",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 3019,
-            "raw": " 11 files changed, 3019 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.2.80"
-        }
-      },
-      {
-        "name": "miow",
-        "notable_parents": "mio",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 3135,
-            "raw": " 16 files changed, 3135 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.3.7"
-        }
-      },
-      {
-        "name": "wasi",
-        "notable_parents": "mio",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 3309,
-            "raw": " 17 files changed, 3309 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.11.0+wasi-snapshot-preview1"
-        }
-      },
-      {
-        "name": "unicode-bidi",
-        "notable_parents": "idna",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 3398,
-            "raw": " 23 files changed, 3398 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.3.7"
-        }
-      },
-      {
-        "name": "quote",
-        "notable_parents": "syn, and 4 others",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 3845,
-            "raw": " 35 files changed, 3845 insertions(+)\n"
-          },
-          "from": null,
-          "to": "1.0.18"
-        }
-      },
-      {
-        "name": "redox_syscall",
-        "notable_parents": "tempfile",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 3897,
-            "raw": " 32 files changed, 3897 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.2.13"
-        }
-      },
-      {
-        "name": "core-foundation",
-        "notable_parents": "security-framework",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 3960,
-            "raw": " 28 files changed, 3960 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.9.3"
-        }
-      },
-      {
-        "name": "tracing-attributes",
-        "notable_parents": "tracing",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 3964,
-            "raw": " 20 files changed, 3964 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.1.20"
-        }
-      },
-      {
-        "name": "ipnet",
-        "notable_parents": "reqwest",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 3980,
-            "raw": " 15 files changed, 3980 insertions(+)\n"
-          },
-          "from": null,
-          "to": "2.4.0"
-        }
-      },
-      {
-        "name": "futures-channel",
-        "notable_parents": "hyper",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 3999,
-            "raw": " 20 files changed, 3999 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.3.21"
-        }
-      },
-      {
-        "name": "tempfile",
-        "notable_parents": "native-tls",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 4066,
-            "raw": " 24 files changed, 4066 insertions(+)\n"
-          },
-          "from": null,
-          "to": "3.3.0"
-        }
-      },
-      {
-        "name": "native-tls",
-        "notable_parents": "reqwest, hyper-tls, tokio-native-tls",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 4089,
-            "raw": " 21 files changed, 4089 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.2.10"
-        }
-      },
-      {
-        "name": "once_cell",
-        "notable_parents": "openssl",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 4140,
-            "raw": " 24 files changed, 4140 insertions(+)\n"
-          },
-          "from": null,
-          "to": "1.10.0"
-        }
-      },
-      {
-        "name": "winreg",
-        "notable_parents": "reqwest",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 4276,
-            "raw": " 29 files changed, 4276 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.10.1"
-        }
-      },
-      {
-        "name": "ryu",
-        "notable_parents": "serde_json, serde_urlencoded",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 4531,
-            "raw": " 37 files changed, 4531 insertions(+)\n"
-          },
-          "from": null,
-          "to": "1.0.9"
-        }
-      },
-      {
-        "name": "schannel",
-        "notable_parents": "native-tls",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 4607,
-            "raw": " 34 files changed, 4607 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.1.19"
-        }
-      },
-      {
-        "name": "log",
-        "notable_parents": "mio, want, reqwest, and 2 others",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 5632,
-            "raw": " 21 files changed, 5632 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.4.16"
-        }
-      },
-      {
-        "name": "proc-macro2",
-        "notable_parents": "syn, quote, and 3 others",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 5702,
-            "raw": " 22 files changed, 5702 insertions(+)\n"
-          },
-          "from": null,
-          "to": "1.0.37"
-        }
-      },
-      {
-        "name": "socket2",
-        "notable_parents": "hyper, tokio",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 6018,
-            "raw": " 13 files changed, 6018 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.4.4"
-        }
-      },
-      {
-        "name": "pin-project-lite",
-        "notable_parents": "hyper, tokio, reqwest, and 4 others",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 6107,
-            "raw": " 72 files changed, 6107 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.2.8"
-        }
-      },
-      {
-        "name": "tracing-core",
-        "notable_parents": "tracing",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 6163,
-            "raw": " 28 files changed, 6163 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.1.25"
-        }
-      },
-      {
-        "name": "cc",
-        "notable_parents": "openssl-sys",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 6671,
-            "raw": " 22 files changed, 6671 insertions(+)\n"
-          },
-          "from": null,
-          "to": "1.0.73"
-        }
-      },
-      {
-        "name": "httparse",
-        "notable_parents": "hyper",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 7265,
-            "raw": " 20 files changed, 7265 insertions(+)\n"
-          },
-          "from": null,
-          "to": "1.7.0"
-        }
-      },
-      {
-        "name": "memchr",
-        "notable_parents": "tokio, os_str_bytes",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 8718,
-            "raw": " 48 files changed, 8718 insertions(+)\n"
-          },
-          "from": null,
-          "to": "2.4.1"
-        }
-      },
-      {
-        "name": "bytes",
-        "notable_parents": "h2, http, hyper, tokio, and 4 others",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 9213,
-            "raw": " 45 files changed, 9213 insertions(+)\n"
-          },
-          "from": null,
-          "to": "1.1.0"
-        }
-      },
-      {
-        "name": "openssl-sys",
-        "notable_parents": "openssl, native-tls",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 9484,
-            "raw": " 48 files changed, 9484 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.9.72"
-        }
-      },
-      {
-        "name": "security-framework",
-        "notable_parents": "native-tls",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 9776,
-            "raw": " 45 files changed, 9776 insertions(+)\n"
-          },
-          "from": null,
-          "to": "2.6.1"
-        }
-      },
-      {
-        "name": "bumpalo",
-        "notable_parents": "wasm-bindgen-backend",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 10106,
-            "raw": " 19 files changed, 10106 insertions(+)\n"
-          },
-          "from": null,
-          "to": "3.9.1"
-        }
-      },
-      {
-        "name": "tracing",
-        "notable_parents": "h2, hyper, tokio-util",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 10957,
-            "raw": " 34 files changed, 10957 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.1.33"
-        }
-      },
-      {
-        "name": "mio",
-        "notable_parents": "tokio",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 11882,
-            "raw": " 65 files changed, 11882 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.8.2"
-        }
-      },
-      {
-        "name": "js-sys",
-        "notable_parents": "reqwest, web-sys, wasm-bindgen-futures",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 12875,
-            "raw": " 63 files changed, 12875 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.3.57"
-        }
-      },
-      {
-        "name": "tokio-util",
-        "notable_parents": "h2",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 13877,
-            "raw": " 67 files changed, 13877 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.7.1"
-        }
-      },
-      {
-        "name": "hashbrown",
-        "notable_parents": "indexmap",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 14609,
-            "raw": " 33 files changed, 14609 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.11.2"
-        }
-      },
-      {
-        "name": "serde",
-        "notable_parents": "reqwest, serde_json, serde_urlencoded",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 16148,
-            "raw": " 29 files changed, 16148 insertions(+)\n"
-          },
-          "from": null,
-          "to": "1.0.136"
-        }
-      },
-      {
-        "name": "url",
-        "notable_parents": "reqwest",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 16350,
-            "raw": " 17 files changed, 16350 insertions(+)\n"
-          },
-          "from": null,
-          "to": "2.2.2"
-        }
-      },
-      {
-        "name": "tinyvec",
-        "notable_parents": "unicode-normalization",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 16758,
-            "raw": " 27 files changed, 16758 insertions(+)\n"
-          },
-          "from": null,
-          "to": "1.5.1"
-        }
-      },
-      {
-        "name": "http",
-        "notable_parents": "h2, hyper, reqwest, http-body",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 16826,
-            "raw": " 41 files changed, 16826 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.2.6"
-        }
-      },
-      {
-        "name": "wasm-bindgen",
-        "notable_parents": "js-sys, reqwest, web-sys, wasm-bindgen-futures",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 20978,
-            "raw": " 243 files changed, 20978 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.2.80"
-        }
-      },
-      {
-        "name": "ntapi",
-        "notable_parents": "mio",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 21234,
-            "raw": " 44 files changed, 21234 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.3.7"
-        }
-      },
-      {
-        "name": "futures-util",
-        "notable_parents": "h2, hyper, reqwest",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 25074,
-            "raw": " 187 files changed, 25074 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.3.21"
-        }
-      },
-      {
-        "name": "hyper",
-        "notable_parents": "reqwest, hyper-tls",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 25617,
-            "raw": " 72 files changed, 25617 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.14.18"
-        }
-      },
-      {
-        "name": "h2",
-        "notable_parents": "hyper, reqwest",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 26066,
-            "raw": " 66 files changed, 26066 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.3.13"
-        }
-      },
-      {
-        "name": "syn",
-        "notable_parents": "tracing-attributes, and 2 others",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 28477,
-            "raw": " 93 files changed, 21776 insertions(+), 6701 deletions(-)\n"
-          },
-          "from": "1.0.0",
-          "to": "1.0.91"
-        }
-      },
-      {
-        "name": "unicode-normalization",
-        "notable_parents": "idna",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 28628,
-            "raw": " 26 files changed, 28628 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.1.19"
-        }
-      },
-      {
-        "name": "openssl",
-        "notable_parents": "native-tls",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 28634,
-            "raw": " 85 files changed, 28634 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.10.38"
-        }
-      },
-      {
-        "name": "idna",
-        "notable_parents": "url",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 32538,
-            "raw": " 19 files changed, 32538 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.2.3"
-        }
-      },
-      {
-        "name": "vcpkg",
-        "notable_parents": "openssl-sys",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 42648,
-            "raw": " 834 files changed, 42648 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.2.15"
-        }
-      },
-      {
-        "name": "web-sys",
-        "notable_parents": "reqwest, wasm-bindgen-futures",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 197014,
-            "raw": " 2203 files changed, 197014 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.3.57"
-        }
-      },
-      {
-        "name": "encoding_rs",
-        "notable_parents": "reqwest",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 507252,
-            "raw": " 104 files changed, 507252 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.8.31"
-        }
-      }
-    ],
     "total_lines": 1742618
   }
 }

--- a/tests/snapshots/test_cli__test-project-suggest-json.snap
+++ b/tests/snapshots/test_cli__test-project-suggest-json.snap
@@ -709,7 +709,8 @@ stdout:
             "raw": " 11 files changed, 938 insertions(+)\n",
             "count": 938
           }
-        }
+        },
+        "confident": true
       },
       {
         "name": "termcolor",
@@ -724,7 +725,8 @@ stdout:
             "raw": " 12 files changed, 2585 insertions(+)\n",
             "count": 2585
           }
-        }
+        },
+        "confident": true
       },
       {
         "name": "os_str_bytes",
@@ -739,7 +741,8 @@ stdout:
             "raw": " 23 files changed, 2918 insertions(+)\n",
             "count": 2918
           }
-        }
+        },
+        "confident": true
       },
       {
         "name": "textwrap",
@@ -754,7 +757,8 @@ stdout:
             "raw": " 18 files changed, 6165 insertions(+)\n",
             "count": 6165
           }
-        }
+        },
+        "confident": true
       },
       {
         "name": "indexmap",
@@ -769,7 +773,8 @@ stdout:
             "raw": " 33 files changed, 9452 insertions(+)\n",
             "count": 9452
           }
-        }
+        },
+        "confident": true
       },
       {
         "name": "reqwest",
@@ -784,7 +789,8 @@ stdout:
             "raw": " 63 files changed, 21663 insertions(+)\n",
             "count": 21663
           }
-        }
+        },
+        "confident": true
       },
       {
         "name": "serde_json",
@@ -799,7 +805,8 @@ stdout:
             "raw": " 88 files changed, 22855 insertions(+)\n",
             "count": 22855
           }
-        }
+        },
+        "confident": true
       },
       {
         "name": "tokio",
@@ -814,7 +821,8 @@ stdout:
             "raw": " 405 files changed, 91278 insertions(+)\n",
             "count": 91278
           }
-        }
+        },
+        "confident": true
       },
       {
         "name": "libc",
@@ -829,7 +837,8 @@ stdout:
             "raw": " 217 files changed, 94067 insertions(+)\n",
             "count": 94067
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "winapi",
@@ -844,7 +853,8 @@ stdout:
             "raw": " 412 files changed, 181329 insertions(+)\n",
             "count": 181329
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "tinyvec_macros",
@@ -859,7 +869,8 @@ stdout:
             "raw": " 7 files changed, 87 insertions(+)\n",
             "count": 87
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "matches",
@@ -874,7 +885,8 @@ stdout:
             "raw": " 7 files changed, 211 insertions(+)\n",
             "count": 211
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "foreign-types-shared",
@@ -889,7 +901,8 @@ stdout:
             "raw": " 6 files changed, 303 insertions(+)\n",
             "count": 303
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "try-lock",
@@ -904,7 +917,8 @@ stdout:
             "raw": " 8 files changed, 386 insertions(+)\n",
             "count": 386
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "openssl-probe",
@@ -919,7 +933,8 @@ stdout:
             "raw": " 12 files changed, 456 insertions(+)\n",
             "count": 456
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "tower-service",
@@ -934,7 +949,8 @@ stdout:
             "raw": " 8 files changed, 507 insertions(+)\n",
             "count": 507
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "wasm-bindgen-shared",
@@ -949,7 +965,8 @@ stdout:
             "raw": " 8 files changed, 516 insertions(+)\n",
             "count": 516
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "pin-utils",
@@ -964,7 +981,8 @@ stdout:
             "raw": " 15 files changed, 544 insertions(+)\n",
             "count": 544
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "futures-sink",
@@ -979,7 +997,8 @@ stdout:
             "raw": " 8 files changed, 551 insertions(+)\n",
             "count": 551
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "foreign-types",
@@ -994,7 +1013,8 @@ stdout:
             "raw": " 7 files changed, 584 insertions(+)\n",
             "count": 584
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "cfg-if",
@@ -1009,7 +1029,8 @@ stdout:
             "raw": " 11 files changed, 588 insertions(+)\n",
             "count": 588
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "remove_dir_all",
@@ -1024,7 +1045,8 @@ stdout:
             "raw": " 9 files changed, 598 insertions(+)\n",
             "count": 598
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "instant",
@@ -1039,7 +1061,8 @@ stdout:
             "raw": " 14 files changed, 678 insertions(+)\n",
             "count": 678
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "form_urlencoded",
@@ -1054,7 +1077,8 @@ stdout:
             "raw": " 7 files changed, 695 insertions(+)\n",
             "count": 695
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "want",
@@ -1069,7 +1093,8 @@ stdout:
             "raw": " 9 files changed, 703 insertions(+)\n",
             "count": 703
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "percent-encoding",
@@ -1084,7 +1109,8 @@ stdout:
             "raw": " 7 files changed, 708 insertions(+)\n",
             "count": 708
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "fnv",
@@ -1099,7 +1125,8 @@ stdout:
             "raw": " 10 files changed, 736 insertions(+)\n",
             "count": 736
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "itoa",
@@ -1114,7 +1141,8 @@ stdout:
             "raw": " 15 files changed, 796 insertions(+)\n",
             "count": 796
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "lazy_static",
@@ -1129,7 +1157,8 @@ stdout:
             "raw": " 13 files changed, 882 insertions(+)\n",
             "count": 882
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "httpdate",
@@ -1144,7 +1173,8 @@ stdout:
             "raw": " 12 files changed, 1001 insertions(+)\n",
             "count": 1001
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "winapi-util",
@@ -1159,7 +1189,8 @@ stdout:
             "raw": " 15 files changed, 1101 insertions(+)\n",
             "count": 1101
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "winapi-i686-pc-windows-gnu",
@@ -1174,7 +1205,8 @@ stdout:
             "raw": " 1392 files changed, 1133 insertions(+)\n",
             "count": 1133
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "winapi-x86_64-pc-windows-gnu",
@@ -1189,7 +1221,8 @@ stdout:
             "raw": " 1421 files changed, 1168 insertions(+)\n",
             "count": 1168
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "futures-core",
@@ -1204,7 +1237,8 @@ stdout:
             "raw": " 16 files changed, 1182 insertions(+)\n",
             "count": 1182
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "futures-task",
@@ -1219,7 +1253,8 @@ stdout:
             "raw": " 16 files changed, 1187 insertions(+)\n",
             "count": 1187
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "http-body",
@@ -1234,7 +1269,8 @@ stdout:
             "raw": " 19 files changed, 1262 insertions(+)\n",
             "count": 1262
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "wasm-bindgen-macro",
@@ -1249,7 +1285,8 @@ stdout:
             "raw": " 46 files changed, 1275 insertions(+)\n",
             "count": 1275
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "hyper-tls",
@@ -1264,7 +1301,8 @@ stdout:
             "raw": " 14 files changed, 1301 insertions(+)\n",
             "count": 1301
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "wasm-bindgen-futures",
@@ -1279,7 +1317,8 @@ stdout:
             "raw": " 13 files changed, 1304 insertions(+)\n",
             "count": 1304
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "fastrand",
@@ -1294,7 +1333,8 @@ stdout:
             "raw": " 12 files changed, 1375 insertions(+)\n",
             "count": 1375
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "mime",
@@ -1309,7 +1349,8 @@ stdout:
             "raw": " 15 files changed, 1721 insertions(+)\n",
             "count": 1721
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "pkg-config",
@@ -1324,7 +1365,8 @@ stdout:
             "raw": " 16 files changed, 1754 insertions(+)\n",
             "count": 1754
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "tokio-native-tls",
@@ -1339,7 +1381,8 @@ stdout:
             "raw": " 19 files changed, 1804 insertions(+)\n",
             "count": 1804
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "wasm-bindgen-macro-support",
@@ -1354,7 +1397,8 @@ stdout:
             "raw": " 7 files changed, 1966 insertions(+)\n",
             "count": 1966
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "core-foundation-sys",
@@ -1369,7 +1413,8 @@ stdout:
             "raw": " 28 files changed, 1971 insertions(+)\n",
             "count": 1971
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "security-framework-sys",
@@ -1384,7 +1429,8 @@ stdout:
             "raw": " 29 files changed, 2023 insertions(+)\n",
             "count": 2023
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "unicode-xid",
@@ -1399,7 +1445,8 @@ stdout:
             "raw": " 14 files changed, 2050 insertions(+)\n",
             "count": 2050
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "serde_urlencoded",
@@ -1414,7 +1461,8 @@ stdout:
             "raw": " 19 files changed, 2127 insertions(+)\n",
             "count": 2127
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "slab",
@@ -1429,7 +1477,8 @@ stdout:
             "raw": " 11 files changed, 2622 insertions(+)\n",
             "count": 2622
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "wasm-bindgen-backend",
@@ -1444,7 +1493,8 @@ stdout:
             "raw": " 11 files changed, 3019 insertions(+)\n",
             "count": 3019
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "miow",
@@ -1459,7 +1509,8 @@ stdout:
             "raw": " 16 files changed, 3135 insertions(+)\n",
             "count": 3135
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "wasi",
@@ -1474,7 +1525,8 @@ stdout:
             "raw": " 17 files changed, 3309 insertions(+)\n",
             "count": 3309
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "unicode-bidi",
@@ -1489,7 +1541,8 @@ stdout:
             "raw": " 23 files changed, 3398 insertions(+)\n",
             "count": 3398
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "quote",
@@ -1504,7 +1557,8 @@ stdout:
             "raw": " 35 files changed, 3845 insertions(+)\n",
             "count": 3845
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "redox_syscall",
@@ -1519,7 +1573,8 @@ stdout:
             "raw": " 32 files changed, 3897 insertions(+)\n",
             "count": 3897
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "core-foundation",
@@ -1534,7 +1589,8 @@ stdout:
             "raw": " 28 files changed, 3960 insertions(+)\n",
             "count": 3960
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "tracing-attributes",
@@ -1549,7 +1605,8 @@ stdout:
             "raw": " 20 files changed, 3964 insertions(+)\n",
             "count": 3964
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "ipnet",
@@ -1564,7 +1621,8 @@ stdout:
             "raw": " 15 files changed, 3980 insertions(+)\n",
             "count": 3980
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "futures-channel",
@@ -1579,7 +1637,8 @@ stdout:
             "raw": " 20 files changed, 3999 insertions(+)\n",
             "count": 3999
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "tempfile",
@@ -1594,7 +1653,8 @@ stdout:
             "raw": " 24 files changed, 4066 insertions(+)\n",
             "count": 4066
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "native-tls",
@@ -1609,7 +1669,8 @@ stdout:
             "raw": " 21 files changed, 4089 insertions(+)\n",
             "count": 4089
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "once_cell",
@@ -1624,7 +1685,8 @@ stdout:
             "raw": " 24 files changed, 4140 insertions(+)\n",
             "count": 4140
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "winreg",
@@ -1639,7 +1701,8 @@ stdout:
             "raw": " 29 files changed, 4276 insertions(+)\n",
             "count": 4276
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "ryu",
@@ -1654,7 +1717,8 @@ stdout:
             "raw": " 37 files changed, 4531 insertions(+)\n",
             "count": 4531
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "schannel",
@@ -1669,7 +1733,8 @@ stdout:
             "raw": " 34 files changed, 4607 insertions(+)\n",
             "count": 4607
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "log",
@@ -1684,7 +1749,8 @@ stdout:
             "raw": " 21 files changed, 5632 insertions(+)\n",
             "count": 5632
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "proc-macro2",
@@ -1699,7 +1765,8 @@ stdout:
             "raw": " 22 files changed, 5702 insertions(+)\n",
             "count": 5702
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "socket2",
@@ -1714,7 +1781,8 @@ stdout:
             "raw": " 13 files changed, 6018 insertions(+)\n",
             "count": 6018
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "pin-project-lite",
@@ -1729,7 +1797,8 @@ stdout:
             "raw": " 72 files changed, 6107 insertions(+)\n",
             "count": 6107
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "tracing-core",
@@ -1744,7 +1813,8 @@ stdout:
             "raw": " 28 files changed, 6163 insertions(+)\n",
             "count": 6163
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "cc",
@@ -1759,7 +1829,8 @@ stdout:
             "raw": " 22 files changed, 6671 insertions(+)\n",
             "count": 6671
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "httparse",
@@ -1774,7 +1845,8 @@ stdout:
             "raw": " 20 files changed, 7265 insertions(+)\n",
             "count": 7265
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "memchr",
@@ -1789,7 +1861,8 @@ stdout:
             "raw": " 48 files changed, 8718 insertions(+)\n",
             "count": 8718
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "bytes",
@@ -1804,7 +1877,8 @@ stdout:
             "raw": " 45 files changed, 9213 insertions(+)\n",
             "count": 9213
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "openssl-sys",
@@ -1819,7 +1893,8 @@ stdout:
             "raw": " 48 files changed, 9484 insertions(+)\n",
             "count": 9484
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "security-framework",
@@ -1834,7 +1909,8 @@ stdout:
             "raw": " 45 files changed, 9776 insertions(+)\n",
             "count": 9776
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "bumpalo",
@@ -1849,7 +1925,8 @@ stdout:
             "raw": " 19 files changed, 10106 insertions(+)\n",
             "count": 10106
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "tracing",
@@ -1864,7 +1941,8 @@ stdout:
             "raw": " 34 files changed, 10957 insertions(+)\n",
             "count": 10957
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "mio",
@@ -1879,7 +1957,8 @@ stdout:
             "raw": " 65 files changed, 11882 insertions(+)\n",
             "count": 11882
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "js-sys",
@@ -1894,7 +1973,8 @@ stdout:
             "raw": " 63 files changed, 12875 insertions(+)\n",
             "count": 12875
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "tokio-util",
@@ -1909,7 +1989,8 @@ stdout:
             "raw": " 67 files changed, 13877 insertions(+)\n",
             "count": 13877
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "hashbrown",
@@ -1924,7 +2005,8 @@ stdout:
             "raw": " 33 files changed, 14609 insertions(+)\n",
             "count": 14609
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "serde",
@@ -1939,7 +2021,8 @@ stdout:
             "raw": " 29 files changed, 16148 insertions(+)\n",
             "count": 16148
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "url",
@@ -1954,7 +2037,8 @@ stdout:
             "raw": " 17 files changed, 16350 insertions(+)\n",
             "count": 16350
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "tinyvec",
@@ -1969,7 +2053,8 @@ stdout:
             "raw": " 27 files changed, 16758 insertions(+)\n",
             "count": 16758
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "http",
@@ -1984,7 +2069,8 @@ stdout:
             "raw": " 41 files changed, 16826 insertions(+)\n",
             "count": 16826
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "wasm-bindgen",
@@ -1999,7 +2085,8 @@ stdout:
             "raw": " 243 files changed, 20978 insertions(+)\n",
             "count": 20978
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "ntapi",
@@ -2014,7 +2101,8 @@ stdout:
             "raw": " 44 files changed, 21234 insertions(+)\n",
             "count": 21234
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "futures-util",
@@ -2029,7 +2117,8 @@ stdout:
             "raw": " 187 files changed, 25074 insertions(+)\n",
             "count": 25074
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "hyper",
@@ -2044,7 +2133,8 @@ stdout:
             "raw": " 72 files changed, 25617 insertions(+)\n",
             "count": 25617
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "h2",
@@ -2059,7 +2149,8 @@ stdout:
             "raw": " 66 files changed, 26066 insertions(+)\n",
             "count": 26066
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "syn",
@@ -2074,7 +2165,8 @@ stdout:
             "raw": " 93 files changed, 21776 insertions(+), 6701 deletions(-)\n",
             "count": 28477
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "unicode-normalization",
@@ -2089,7 +2181,8 @@ stdout:
             "raw": " 26 files changed, 28628 insertions(+)\n",
             "count": 28628
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "openssl",
@@ -2104,7 +2197,8 @@ stdout:
             "raw": " 85 files changed, 28634 insertions(+)\n",
             "count": 28634
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "idna",
@@ -2119,7 +2213,8 @@ stdout:
             "raw": " 19 files changed, 32538 insertions(+)\n",
             "count": 32538
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "vcpkg",
@@ -2134,7 +2229,8 @@ stdout:
             "raw": " 834 files changed, 42648 insertions(+)\n",
             "count": 42648
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "web-sys",
@@ -2149,7 +2245,8 @@ stdout:
             "raw": " 2203 files changed, 197014 insertions(+)\n",
             "count": 197014
           }
-        }
+        },
+        "confident": false
       },
       {
         "name": "encoding_rs",
@@ -2164,7 +2261,8 @@ stdout:
             "raw": " 104 files changed, 507252 insertions(+)\n",
             "count": 507252
           }
-        }
+        },
+        "confident": false
       }
     ],
     "suggest_by_criteria": {
@@ -2182,7 +2280,8 @@ stdout:
               "raw": " 12 files changed, 2585 insertions(+)\n",
               "count": 2585
             }
-          }
+          },
+          "confident": true
         },
         {
           "name": "os_str_bytes",
@@ -2197,7 +2296,8 @@ stdout:
               "raw": " 23 files changed, 2918 insertions(+)\n",
               "count": 2918
             }
-          }
+          },
+          "confident": true
         },
         {
           "name": "textwrap",
@@ -2212,7 +2312,8 @@ stdout:
               "raw": " 18 files changed, 6165 insertions(+)\n",
               "count": 6165
             }
-          }
+          },
+          "confident": true
         },
         {
           "name": "indexmap",
@@ -2227,7 +2328,8 @@ stdout:
               "raw": " 33 files changed, 9452 insertions(+)\n",
               "count": 9452
             }
-          }
+          },
+          "confident": true
         },
         {
           "name": "reqwest",
@@ -2242,7 +2344,8 @@ stdout:
               "raw": " 63 files changed, 21663 insertions(+)\n",
               "count": 21663
             }
-          }
+          },
+          "confident": true
         },
         {
           "name": "serde_json",
@@ -2257,7 +2360,8 @@ stdout:
               "raw": " 88 files changed, 22855 insertions(+)\n",
               "count": 22855
             }
-          }
+          },
+          "confident": true
         },
         {
           "name": "tokio",
@@ -2272,7 +2376,8 @@ stdout:
               "raw": " 405 files changed, 91278 insertions(+)\n",
               "count": 91278
             }
-          }
+          },
+          "confident": true
         },
         {
           "name": "libc",
@@ -2287,7 +2392,8 @@ stdout:
               "raw": " 217 files changed, 94067 insertions(+)\n",
               "count": 94067
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "winapi",
@@ -2302,7 +2408,8 @@ stdout:
               "raw": " 412 files changed, 181329 insertions(+)\n",
               "count": 181329
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "tinyvec_macros",
@@ -2317,7 +2424,8 @@ stdout:
               "raw": " 7 files changed, 87 insertions(+)\n",
               "count": 87
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "matches",
@@ -2332,7 +2440,8 @@ stdout:
               "raw": " 7 files changed, 211 insertions(+)\n",
               "count": 211
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "foreign-types-shared",
@@ -2347,7 +2456,8 @@ stdout:
               "raw": " 6 files changed, 303 insertions(+)\n",
               "count": 303
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "try-lock",
@@ -2362,7 +2472,8 @@ stdout:
               "raw": " 8 files changed, 386 insertions(+)\n",
               "count": 386
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "openssl-probe",
@@ -2377,7 +2488,8 @@ stdout:
               "raw": " 12 files changed, 456 insertions(+)\n",
               "count": 456
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "tower-service",
@@ -2392,7 +2504,8 @@ stdout:
               "raw": " 8 files changed, 507 insertions(+)\n",
               "count": 507
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "wasm-bindgen-shared",
@@ -2407,7 +2520,8 @@ stdout:
               "raw": " 8 files changed, 516 insertions(+)\n",
               "count": 516
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "pin-utils",
@@ -2422,7 +2536,8 @@ stdout:
               "raw": " 15 files changed, 544 insertions(+)\n",
               "count": 544
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "futures-sink",
@@ -2437,7 +2552,8 @@ stdout:
               "raw": " 8 files changed, 551 insertions(+)\n",
               "count": 551
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "foreign-types",
@@ -2452,7 +2568,8 @@ stdout:
               "raw": " 7 files changed, 584 insertions(+)\n",
               "count": 584
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "cfg-if",
@@ -2467,7 +2584,8 @@ stdout:
               "raw": " 11 files changed, 588 insertions(+)\n",
               "count": 588
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "remove_dir_all",
@@ -2482,7 +2600,8 @@ stdout:
               "raw": " 9 files changed, 598 insertions(+)\n",
               "count": 598
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "instant",
@@ -2497,7 +2616,8 @@ stdout:
               "raw": " 14 files changed, 678 insertions(+)\n",
               "count": 678
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "form_urlencoded",
@@ -2512,7 +2632,8 @@ stdout:
               "raw": " 7 files changed, 695 insertions(+)\n",
               "count": 695
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "want",
@@ -2527,7 +2648,8 @@ stdout:
               "raw": " 9 files changed, 703 insertions(+)\n",
               "count": 703
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "percent-encoding",
@@ -2542,7 +2664,8 @@ stdout:
               "raw": " 7 files changed, 708 insertions(+)\n",
               "count": 708
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "fnv",
@@ -2557,7 +2680,8 @@ stdout:
               "raw": " 10 files changed, 736 insertions(+)\n",
               "count": 736
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "itoa",
@@ -2572,7 +2696,8 @@ stdout:
               "raw": " 15 files changed, 796 insertions(+)\n",
               "count": 796
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "lazy_static",
@@ -2587,7 +2712,8 @@ stdout:
               "raw": " 13 files changed, 882 insertions(+)\n",
               "count": 882
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "httpdate",
@@ -2602,7 +2728,8 @@ stdout:
               "raw": " 12 files changed, 1001 insertions(+)\n",
               "count": 1001
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "winapi-util",
@@ -2617,7 +2744,8 @@ stdout:
               "raw": " 15 files changed, 1101 insertions(+)\n",
               "count": 1101
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "winapi-i686-pc-windows-gnu",
@@ -2632,7 +2760,8 @@ stdout:
               "raw": " 1392 files changed, 1133 insertions(+)\n",
               "count": 1133
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "winapi-x86_64-pc-windows-gnu",
@@ -2647,7 +2776,8 @@ stdout:
               "raw": " 1421 files changed, 1168 insertions(+)\n",
               "count": 1168
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "futures-core",
@@ -2662,7 +2792,8 @@ stdout:
               "raw": " 16 files changed, 1182 insertions(+)\n",
               "count": 1182
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "futures-task",
@@ -2677,7 +2808,8 @@ stdout:
               "raw": " 16 files changed, 1187 insertions(+)\n",
               "count": 1187
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "http-body",
@@ -2692,7 +2824,8 @@ stdout:
               "raw": " 19 files changed, 1262 insertions(+)\n",
               "count": 1262
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "wasm-bindgen-macro",
@@ -2707,7 +2840,8 @@ stdout:
               "raw": " 46 files changed, 1275 insertions(+)\n",
               "count": 1275
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "hyper-tls",
@@ -2722,7 +2856,8 @@ stdout:
               "raw": " 14 files changed, 1301 insertions(+)\n",
               "count": 1301
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "wasm-bindgen-futures",
@@ -2737,7 +2872,8 @@ stdout:
               "raw": " 13 files changed, 1304 insertions(+)\n",
               "count": 1304
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "fastrand",
@@ -2752,7 +2888,8 @@ stdout:
               "raw": " 12 files changed, 1375 insertions(+)\n",
               "count": 1375
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "mime",
@@ -2767,7 +2904,8 @@ stdout:
               "raw": " 15 files changed, 1721 insertions(+)\n",
               "count": 1721
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "pkg-config",
@@ -2782,7 +2920,8 @@ stdout:
               "raw": " 16 files changed, 1754 insertions(+)\n",
               "count": 1754
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "tokio-native-tls",
@@ -2797,7 +2936,8 @@ stdout:
               "raw": " 19 files changed, 1804 insertions(+)\n",
               "count": 1804
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "wasm-bindgen-macro-support",
@@ -2812,7 +2952,8 @@ stdout:
               "raw": " 7 files changed, 1966 insertions(+)\n",
               "count": 1966
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "core-foundation-sys",
@@ -2827,7 +2968,8 @@ stdout:
               "raw": " 28 files changed, 1971 insertions(+)\n",
               "count": 1971
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "security-framework-sys",
@@ -2842,7 +2984,8 @@ stdout:
               "raw": " 29 files changed, 2023 insertions(+)\n",
               "count": 2023
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "unicode-xid",
@@ -2857,7 +3000,8 @@ stdout:
               "raw": " 14 files changed, 2050 insertions(+)\n",
               "count": 2050
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "serde_urlencoded",
@@ -2872,7 +3016,8 @@ stdout:
               "raw": " 19 files changed, 2127 insertions(+)\n",
               "count": 2127
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "slab",
@@ -2887,7 +3032,8 @@ stdout:
               "raw": " 11 files changed, 2622 insertions(+)\n",
               "count": 2622
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "wasm-bindgen-backend",
@@ -2902,7 +3048,8 @@ stdout:
               "raw": " 11 files changed, 3019 insertions(+)\n",
               "count": 3019
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "miow",
@@ -2917,7 +3064,8 @@ stdout:
               "raw": " 16 files changed, 3135 insertions(+)\n",
               "count": 3135
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "wasi",
@@ -2932,7 +3080,8 @@ stdout:
               "raw": " 17 files changed, 3309 insertions(+)\n",
               "count": 3309
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "unicode-bidi",
@@ -2947,7 +3096,8 @@ stdout:
               "raw": " 23 files changed, 3398 insertions(+)\n",
               "count": 3398
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "quote",
@@ -2962,7 +3112,8 @@ stdout:
               "raw": " 35 files changed, 3845 insertions(+)\n",
               "count": 3845
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "redox_syscall",
@@ -2977,7 +3128,8 @@ stdout:
               "raw": " 32 files changed, 3897 insertions(+)\n",
               "count": 3897
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "core-foundation",
@@ -2992,7 +3144,8 @@ stdout:
               "raw": " 28 files changed, 3960 insertions(+)\n",
               "count": 3960
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "tracing-attributes",
@@ -3007,7 +3160,8 @@ stdout:
               "raw": " 20 files changed, 3964 insertions(+)\n",
               "count": 3964
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "ipnet",
@@ -3022,7 +3176,8 @@ stdout:
               "raw": " 15 files changed, 3980 insertions(+)\n",
               "count": 3980
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "futures-channel",
@@ -3037,7 +3192,8 @@ stdout:
               "raw": " 20 files changed, 3999 insertions(+)\n",
               "count": 3999
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "tempfile",
@@ -3052,7 +3208,8 @@ stdout:
               "raw": " 24 files changed, 4066 insertions(+)\n",
               "count": 4066
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "native-tls",
@@ -3067,7 +3224,8 @@ stdout:
               "raw": " 21 files changed, 4089 insertions(+)\n",
               "count": 4089
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "once_cell",
@@ -3082,7 +3240,8 @@ stdout:
               "raw": " 24 files changed, 4140 insertions(+)\n",
               "count": 4140
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "winreg",
@@ -3097,7 +3256,8 @@ stdout:
               "raw": " 29 files changed, 4276 insertions(+)\n",
               "count": 4276
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "ryu",
@@ -3112,7 +3272,8 @@ stdout:
               "raw": " 37 files changed, 4531 insertions(+)\n",
               "count": 4531
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "schannel",
@@ -3127,7 +3288,8 @@ stdout:
               "raw": " 34 files changed, 4607 insertions(+)\n",
               "count": 4607
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "log",
@@ -3142,7 +3304,8 @@ stdout:
               "raw": " 21 files changed, 5632 insertions(+)\n",
               "count": 5632
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "proc-macro2",
@@ -3157,7 +3320,8 @@ stdout:
               "raw": " 22 files changed, 5702 insertions(+)\n",
               "count": 5702
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "socket2",
@@ -3172,7 +3336,8 @@ stdout:
               "raw": " 13 files changed, 6018 insertions(+)\n",
               "count": 6018
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "pin-project-lite",
@@ -3187,7 +3352,8 @@ stdout:
               "raw": " 72 files changed, 6107 insertions(+)\n",
               "count": 6107
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "tracing-core",
@@ -3202,7 +3368,8 @@ stdout:
               "raw": " 28 files changed, 6163 insertions(+)\n",
               "count": 6163
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "cc",
@@ -3217,7 +3384,8 @@ stdout:
               "raw": " 22 files changed, 6671 insertions(+)\n",
               "count": 6671
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "httparse",
@@ -3232,7 +3400,8 @@ stdout:
               "raw": " 20 files changed, 7265 insertions(+)\n",
               "count": 7265
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "memchr",
@@ -3247,7 +3416,8 @@ stdout:
               "raw": " 48 files changed, 8718 insertions(+)\n",
               "count": 8718
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "bytes",
@@ -3262,7 +3432,8 @@ stdout:
               "raw": " 45 files changed, 9213 insertions(+)\n",
               "count": 9213
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "openssl-sys",
@@ -3277,7 +3448,8 @@ stdout:
               "raw": " 48 files changed, 9484 insertions(+)\n",
               "count": 9484
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "security-framework",
@@ -3292,7 +3464,8 @@ stdout:
               "raw": " 45 files changed, 9776 insertions(+)\n",
               "count": 9776
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "bumpalo",
@@ -3307,7 +3480,8 @@ stdout:
               "raw": " 19 files changed, 10106 insertions(+)\n",
               "count": 10106
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "tracing",
@@ -3322,7 +3496,8 @@ stdout:
               "raw": " 34 files changed, 10957 insertions(+)\n",
               "count": 10957
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "mio",
@@ -3337,7 +3512,8 @@ stdout:
               "raw": " 65 files changed, 11882 insertions(+)\n",
               "count": 11882
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "js-sys",
@@ -3352,7 +3528,8 @@ stdout:
               "raw": " 63 files changed, 12875 insertions(+)\n",
               "count": 12875
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "tokio-util",
@@ -3367,7 +3544,8 @@ stdout:
               "raw": " 67 files changed, 13877 insertions(+)\n",
               "count": 13877
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "hashbrown",
@@ -3382,7 +3560,8 @@ stdout:
               "raw": " 33 files changed, 14609 insertions(+)\n",
               "count": 14609
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "serde",
@@ -3397,7 +3576,8 @@ stdout:
               "raw": " 29 files changed, 16148 insertions(+)\n",
               "count": 16148
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "url",
@@ -3412,7 +3592,8 @@ stdout:
               "raw": " 17 files changed, 16350 insertions(+)\n",
               "count": 16350
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "tinyvec",
@@ -3427,7 +3608,8 @@ stdout:
               "raw": " 27 files changed, 16758 insertions(+)\n",
               "count": 16758
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "http",
@@ -3442,7 +3624,8 @@ stdout:
               "raw": " 41 files changed, 16826 insertions(+)\n",
               "count": 16826
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "wasm-bindgen",
@@ -3457,7 +3640,8 @@ stdout:
               "raw": " 243 files changed, 20978 insertions(+)\n",
               "count": 20978
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "ntapi",
@@ -3472,7 +3656,8 @@ stdout:
               "raw": " 44 files changed, 21234 insertions(+)\n",
               "count": 21234
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "futures-util",
@@ -3487,7 +3672,8 @@ stdout:
               "raw": " 187 files changed, 25074 insertions(+)\n",
               "count": 25074
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "hyper",
@@ -3502,7 +3688,8 @@ stdout:
               "raw": " 72 files changed, 25617 insertions(+)\n",
               "count": 25617
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "h2",
@@ -3517,7 +3704,8 @@ stdout:
               "raw": " 66 files changed, 26066 insertions(+)\n",
               "count": 26066
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "syn",
@@ -3532,7 +3720,8 @@ stdout:
               "raw": " 93 files changed, 21776 insertions(+), 6701 deletions(-)\n",
               "count": 28477
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "unicode-normalization",
@@ -3547,7 +3736,8 @@ stdout:
               "raw": " 26 files changed, 28628 insertions(+)\n",
               "count": 28628
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "openssl",
@@ -3562,7 +3752,8 @@ stdout:
               "raw": " 85 files changed, 28634 insertions(+)\n",
               "count": 28634
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "idna",
@@ -3577,7 +3768,8 @@ stdout:
               "raw": " 19 files changed, 32538 insertions(+)\n",
               "count": 32538
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "vcpkg",
@@ -3592,7 +3784,8 @@ stdout:
               "raw": " 834 files changed, 42648 insertions(+)\n",
               "count": 42648
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "web-sys",
@@ -3607,7 +3800,8 @@ stdout:
               "raw": " 2203 files changed, 197014 insertions(+)\n",
               "count": 197014
             }
-          }
+          },
+          "confident": false
         },
         {
           "name": "encoding_rs",
@@ -3622,7 +3816,8 @@ stdout:
               "raw": " 104 files changed, 507252 insertions(+)\n",
               "count": 507252
             }
-          }
+          },
+          "confident": false
         }
       ],
       "safe-to-run": [
@@ -3639,7 +3834,8 @@ stdout:
               "raw": " 11 files changed, 938 insertions(+)\n",
               "count": 938
             }
-          }
+          },
+          "confident": true
         }
       ]
     },

--- a/tests/snapshots/test_cli__test-project-suggest-shallow-json.snap
+++ b/tests/snapshots/test_cli__test-project-suggest-shallow-json.snap
@@ -93,7 +93,8 @@ stdout:
             "raw": " 11 files changed, 938 insertions(+)\n",
             "count": 938
           }
-        }
+        },
+        "confident": true
       },
       {
         "name": "termcolor",
@@ -108,7 +109,8 @@ stdout:
             "raw": " 12 files changed, 2585 insertions(+)\n",
             "count": 2585
           }
-        }
+        },
+        "confident": true
       },
       {
         "name": "os_str_bytes",
@@ -123,7 +125,8 @@ stdout:
             "raw": " 23 files changed, 2918 insertions(+)\n",
             "count": 2918
           }
-        }
+        },
+        "confident": true
       },
       {
         "name": "textwrap",
@@ -138,7 +141,8 @@ stdout:
             "raw": " 18 files changed, 6165 insertions(+)\n",
             "count": 6165
           }
-        }
+        },
+        "confident": true
       },
       {
         "name": "indexmap",
@@ -153,7 +157,8 @@ stdout:
             "raw": " 33 files changed, 9452 insertions(+)\n",
             "count": 9452
           }
-        }
+        },
+        "confident": true
       },
       {
         "name": "reqwest",
@@ -168,7 +173,8 @@ stdout:
             "raw": " 63 files changed, 21663 insertions(+)\n",
             "count": 21663
           }
-        }
+        },
+        "confident": true
       },
       {
         "name": "serde_json",
@@ -183,7 +189,8 @@ stdout:
             "raw": " 88 files changed, 22855 insertions(+)\n",
             "count": 22855
           }
-        }
+        },
+        "confident": true
       },
       {
         "name": "tokio",
@@ -198,7 +205,8 @@ stdout:
             "raw": " 405 files changed, 91278 insertions(+)\n",
             "count": 91278
           }
-        }
+        },
+        "confident": true
       },
       {
         "name": "libc",
@@ -213,7 +221,8 @@ stdout:
             "raw": " 217 files changed, 94067 insertions(+)\n",
             "count": 94067
           }
-        }
+        },
+        "confident": true
       },
       {
         "name": "winapi",
@@ -228,7 +237,8 @@ stdout:
             "raw": " 412 files changed, 181329 insertions(+)\n",
             "count": 181329
           }
-        }
+        },
+        "confident": true
       }
     ],
     "suggest_by_criteria": {
@@ -246,7 +256,8 @@ stdout:
               "raw": " 12 files changed, 2585 insertions(+)\n",
               "count": 2585
             }
-          }
+          },
+          "confident": true
         },
         {
           "name": "os_str_bytes",
@@ -261,7 +272,8 @@ stdout:
               "raw": " 23 files changed, 2918 insertions(+)\n",
               "count": 2918
             }
-          }
+          },
+          "confident": true
         },
         {
           "name": "textwrap",
@@ -276,7 +288,8 @@ stdout:
               "raw": " 18 files changed, 6165 insertions(+)\n",
               "count": 6165
             }
-          }
+          },
+          "confident": true
         },
         {
           "name": "indexmap",
@@ -291,7 +304,8 @@ stdout:
               "raw": " 33 files changed, 9452 insertions(+)\n",
               "count": 9452
             }
-          }
+          },
+          "confident": true
         },
         {
           "name": "reqwest",
@@ -306,7 +320,8 @@ stdout:
               "raw": " 63 files changed, 21663 insertions(+)\n",
               "count": 21663
             }
-          }
+          },
+          "confident": true
         },
         {
           "name": "serde_json",
@@ -321,7 +336,8 @@ stdout:
               "raw": " 88 files changed, 22855 insertions(+)\n",
               "count": 22855
             }
-          }
+          },
+          "confident": true
         },
         {
           "name": "tokio",
@@ -336,7 +352,8 @@ stdout:
               "raw": " 405 files changed, 91278 insertions(+)\n",
               "count": 91278
             }
-          }
+          },
+          "confident": true
         }
       ],
       "safe-to-run": [
@@ -353,7 +370,8 @@ stdout:
               "raw": " 11 files changed, 938 insertions(+)\n",
               "count": 938
             }
-          }
+          },
+          "confident": true
         },
         {
           "name": "libc",
@@ -368,7 +386,8 @@ stdout:
               "raw": " 217 files changed, 94067 insertions(+)\n",
               "count": 94067
             }
-          }
+          },
+          "confident": true
         },
         {
           "name": "winapi",
@@ -383,7 +402,8 @@ stdout:
               "raw": " 412 files changed, 181329 insertions(+)\n",
               "count": 181329
             }
-          }
+          },
+          "confident": true
         }
       ]
     },

--- a/tests/snapshots/test_cli__test-project-suggest-shallow-json.snap
+++ b/tests/snapshots/test_cli__test-project-suggest-shallow-json.snap
@@ -4,80 +4,233 @@ expression: format_outputs(&output)
 ---
 stdout:
 {
+  "context": null,
   "conclusion": "fail (vetting)",
   "failures": [
     {
-      "missing_criteria": [
-        "safe-to-run"
-      ],
       "name": "hermit-abi",
-      "version": "0.1.19"
+      "version": "0.1.19",
+      "missing_criteria": [
+        "safe-to-run"
+      ]
     },
     {
-      "missing_criteria": [
-        "safe-to-deploy"
-      ],
       "name": "indexmap",
-      "version": "1.8.1"
+      "version": "1.8.1",
+      "missing_criteria": [
+        "safe-to-deploy"
+      ]
     },
     {
-      "missing_criteria": [
-        "safe-to-run"
-      ],
       "name": "libc",
-      "version": "0.2.123"
-    },
-    {
-      "missing_criteria": [
-        "safe-to-deploy"
-      ],
-      "name": "os_str_bytes",
-      "version": "6.0.0"
-    },
-    {
-      "missing_criteria": [
-        "safe-to-deploy"
-      ],
-      "name": "reqwest",
-      "version": "0.11.10"
-    },
-    {
-      "missing_criteria": [
-        "safe-to-deploy"
-      ],
-      "name": "serde_json",
-      "version": "1.0.79"
-    },
-    {
-      "missing_criteria": [
-        "safe-to-deploy"
-      ],
-      "name": "termcolor",
-      "version": "1.1.3"
-    },
-    {
-      "missing_criteria": [
-        "safe-to-deploy"
-      ],
-      "name": "textwrap",
-      "version": "0.15.0"
-    },
-    {
-      "missing_criteria": [
-        "safe-to-deploy"
-      ],
-      "name": "tokio",
-      "version": "1.17.0"
-    },
-    {
+      "version": "0.2.123",
       "missing_criteria": [
         "safe-to-run"
-      ],
+      ]
+    },
+    {
+      "name": "os_str_bytes",
+      "version": "6.0.0",
+      "missing_criteria": [
+        "safe-to-deploy"
+      ]
+    },
+    {
+      "name": "reqwest",
+      "version": "0.11.10",
+      "missing_criteria": [
+        "safe-to-deploy"
+      ]
+    },
+    {
+      "name": "serde_json",
+      "version": "1.0.79",
+      "missing_criteria": [
+        "safe-to-deploy"
+      ]
+    },
+    {
+      "name": "termcolor",
+      "version": "1.1.3",
+      "missing_criteria": [
+        "safe-to-deploy"
+      ]
+    },
+    {
+      "name": "textwrap",
+      "version": "0.15.0",
+      "missing_criteria": [
+        "safe-to-deploy"
+      ]
+    },
+    {
+      "name": "tokio",
+      "version": "1.17.0",
+      "missing_criteria": [
+        "safe-to-deploy"
+      ]
+    },
+    {
       "name": "winapi",
-      "version": "0.3.9"
+      "version": "0.3.9",
+      "missing_criteria": [
+        "safe-to-run"
+      ]
     }
   ],
   "suggest": {
+    "suggestions": [
+      {
+        "name": "hermit-abi",
+        "notable_parents": "atty",
+        "suggested_criteria": [
+          "safe-to-run"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.1.19",
+          "diffstat": {
+            "raw": " 11 files changed, 938 insertions(+)\n",
+            "count": 938
+          }
+        }
+      },
+      {
+        "name": "termcolor",
+        "notable_parents": "clap",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "1.1.3",
+          "diffstat": {
+            "raw": " 12 files changed, 2585 insertions(+)\n",
+            "count": 2585
+          }
+        }
+      },
+      {
+        "name": "os_str_bytes",
+        "notable_parents": "clap",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "6.0.0",
+          "diffstat": {
+            "raw": " 23 files changed, 2918 insertions(+)\n",
+            "count": 2918
+          }
+        }
+      },
+      {
+        "name": "textwrap",
+        "notable_parents": "clap",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.15.0",
+          "diffstat": {
+            "raw": " 18 files changed, 6165 insertions(+)\n",
+            "count": 6165
+          }
+        }
+      },
+      {
+        "name": "indexmap",
+        "notable_parents": "h2, clap",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "1.8.1",
+          "diffstat": {
+            "raw": " 33 files changed, 9452 insertions(+)\n",
+            "count": 9452
+          }
+        }
+      },
+      {
+        "name": "reqwest",
+        "notable_parents": "test-project",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.11.10",
+          "diffstat": {
+            "raw": " 63 files changed, 21663 insertions(+)\n",
+            "count": 21663
+          }
+        }
+      },
+      {
+        "name": "serde_json",
+        "notable_parents": "reqwest, test-project",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "1.0.79",
+          "diffstat": {
+            "raw": " 88 files changed, 22855 insertions(+)\n",
+            "count": 22855
+          }
+        }
+      },
+      {
+        "name": "tokio",
+        "notable_parents": "h2, hyper, reqwest, and 4 others",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "1.17.0",
+          "diffstat": {
+            "raw": " 405 files changed, 91278 insertions(+)\n",
+            "count": 91278
+          }
+        }
+      },
+      {
+        "name": "libc",
+        "notable_parents": "mio, atty, tokio, openssl, and 8 others",
+        "suggested_criteria": [
+          "safe-to-run"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.2.123",
+          "diffstat": {
+            "raw": " 217 files changed, 94067 insertions(+)\n",
+            "count": 94067
+          }
+        }
+      },
+      {
+        "name": "winapi",
+        "notable_parents": "mio, atty, miow, ntapi, and 7 others",
+        "suggested_criteria": [
+          "safe-to-run"
+        ],
+        "suggested_diff": {
+          "from": null,
+          "to": "0.3.9",
+          "diffstat": {
+            "raw": " 412 files changed, 181329 insertions(+)\n",
+            "count": 181329
+          }
+        }
+      }
+    ],
     "suggest_by_criteria": {
       "safe-to-deploy": [
         {
@@ -87,12 +240,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 2585,
-              "raw": " 12 files changed, 2585 insertions(+)\n"
-            },
             "from": null,
-            "to": "1.1.3"
+            "to": "1.1.3",
+            "diffstat": {
+              "raw": " 12 files changed, 2585 insertions(+)\n",
+              "count": 2585
+            }
           }
         },
         {
@@ -102,12 +255,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 2918,
-              "raw": " 23 files changed, 2918 insertions(+)\n"
-            },
             "from": null,
-            "to": "6.0.0"
+            "to": "6.0.0",
+            "diffstat": {
+              "raw": " 23 files changed, 2918 insertions(+)\n",
+              "count": 2918
+            }
           }
         },
         {
@@ -117,12 +270,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 6165,
-              "raw": " 18 files changed, 6165 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.15.0"
+            "to": "0.15.0",
+            "diffstat": {
+              "raw": " 18 files changed, 6165 insertions(+)\n",
+              "count": 6165
+            }
           }
         },
         {
@@ -132,12 +285,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 9452,
-              "raw": " 33 files changed, 9452 insertions(+)\n"
-            },
             "from": null,
-            "to": "1.8.1"
+            "to": "1.8.1",
+            "diffstat": {
+              "raw": " 33 files changed, 9452 insertions(+)\n",
+              "count": 9452
+            }
           }
         },
         {
@@ -147,12 +300,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 21663,
-              "raw": " 63 files changed, 21663 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.11.10"
+            "to": "0.11.10",
+            "diffstat": {
+              "raw": " 63 files changed, 21663 insertions(+)\n",
+              "count": 21663
+            }
           }
         },
         {
@@ -162,12 +315,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 22855,
-              "raw": " 88 files changed, 22855 insertions(+)\n"
-            },
             "from": null,
-            "to": "1.0.79"
+            "to": "1.0.79",
+            "diffstat": {
+              "raw": " 88 files changed, 22855 insertions(+)\n",
+              "count": 22855
+            }
           }
         },
         {
@@ -177,12 +330,12 @@ stdout:
             "safe-to-deploy"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 91278,
-              "raw": " 405 files changed, 91278 insertions(+)\n"
-            },
             "from": null,
-            "to": "1.17.0"
+            "to": "1.17.0",
+            "diffstat": {
+              "raw": " 405 files changed, 91278 insertions(+)\n",
+              "count": 91278
+            }
           }
         }
       ],
@@ -194,12 +347,12 @@ stdout:
             "safe-to-run"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 938,
-              "raw": " 11 files changed, 938 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.1.19"
+            "to": "0.1.19",
+            "diffstat": {
+              "raw": " 11 files changed, 938 insertions(+)\n",
+              "count": 938
+            }
           }
         },
         {
@@ -209,12 +362,12 @@ stdout:
             "safe-to-run"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 94067,
-              "raw": " 217 files changed, 94067 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.2.123"
+            "to": "0.2.123",
+            "diffstat": {
+              "raw": " 217 files changed, 94067 insertions(+)\n",
+              "count": 94067
+            }
           }
         },
         {
@@ -224,168 +377,16 @@ stdout:
             "safe-to-run"
           ],
           "suggested_diff": {
-            "diffstat": {
-              "count": 181329,
-              "raw": " 412 files changed, 181329 insertions(+)\n"
-            },
             "from": null,
-            "to": "0.3.9"
+            "to": "0.3.9",
+            "diffstat": {
+              "raw": " 412 files changed, 181329 insertions(+)\n",
+              "count": 181329
+            }
           }
         }
       ]
     },
-    "suggestions": [
-      {
-        "name": "hermit-abi",
-        "notable_parents": "atty",
-        "suggested_criteria": [
-          "safe-to-run"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 938,
-            "raw": " 11 files changed, 938 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.1.19"
-        }
-      },
-      {
-        "name": "termcolor",
-        "notable_parents": "clap",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 2585,
-            "raw": " 12 files changed, 2585 insertions(+)\n"
-          },
-          "from": null,
-          "to": "1.1.3"
-        }
-      },
-      {
-        "name": "os_str_bytes",
-        "notable_parents": "clap",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 2918,
-            "raw": " 23 files changed, 2918 insertions(+)\n"
-          },
-          "from": null,
-          "to": "6.0.0"
-        }
-      },
-      {
-        "name": "textwrap",
-        "notable_parents": "clap",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 6165,
-            "raw": " 18 files changed, 6165 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.15.0"
-        }
-      },
-      {
-        "name": "indexmap",
-        "notable_parents": "h2, clap",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 9452,
-            "raw": " 33 files changed, 9452 insertions(+)\n"
-          },
-          "from": null,
-          "to": "1.8.1"
-        }
-      },
-      {
-        "name": "reqwest",
-        "notable_parents": "test-project",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 21663,
-            "raw": " 63 files changed, 21663 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.11.10"
-        }
-      },
-      {
-        "name": "serde_json",
-        "notable_parents": "reqwest, test-project",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 22855,
-            "raw": " 88 files changed, 22855 insertions(+)\n"
-          },
-          "from": null,
-          "to": "1.0.79"
-        }
-      },
-      {
-        "name": "tokio",
-        "notable_parents": "h2, hyper, reqwest, and 4 others",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 91278,
-            "raw": " 405 files changed, 91278 insertions(+)\n"
-          },
-          "from": null,
-          "to": "1.17.0"
-        }
-      },
-      {
-        "name": "libc",
-        "notable_parents": "mio, atty, tokio, openssl, and 8 others",
-        "suggested_criteria": [
-          "safe-to-run"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 94067,
-            "raw": " 217 files changed, 94067 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.2.123"
-        }
-      },
-      {
-        "name": "winapi",
-        "notable_parents": "mio, atty, miow, ntapi, and 7 others",
-        "suggested_criteria": [
-          "safe-to-run"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 181329,
-            "raw": " 412 files changed, 181329 insertions(+)\n"
-          },
-          "from": null,
-          "to": "0.3.9"
-        }
-      }
-    ],
     "total_lines": 433250
   }
 }

--- a/tests/test-cli.rs
+++ b/tests/test-cli.rs
@@ -200,7 +200,6 @@ fn test_project_suggest_json() {
     assert!(output.status.success(), "{}", output.status);
 }
 
-
 #[test]
 fn test_project_suggest_json_full() {
     let project = PathBuf::from(env!("CARGO_MANIFEST_DIR"))

--- a/tests/test-cli.rs
+++ b/tests/test-cli.rs
@@ -200,6 +200,32 @@ fn test_project_suggest_json() {
     assert!(output.status.success(), "{}", output.status);
 }
 
+
+#[test]
+fn test_project_suggest_json_full() {
+    let project = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("test-project");
+    let bin = env!("CARGO_BIN_EXE_cargo-vet");
+    let output = Command::new(bin)
+        .current_dir(&project)
+        .arg("vet")
+        .arg("suggest")
+        .arg("--diff-cache")
+        .arg("../diff-cache.toml")
+        .arg("--manifest-path")
+        .arg("Cargo.toml")
+        .arg("--output-format=json-full")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .unwrap();
+
+    // Can't snapshot this because cargo-metadata has some HashMaps :(
+    // insta::assert_snapshot!(format_outputs(&output));
+    assert!(output.status.success(), "{}", output.status);
+}
+
 #[test]
 fn test_project_suggest_shallow() {
     let project = PathBuf::from(env!("CARGO_MANIFEST_DIR"))


### PR DESCRIPTION
[Workflow Design Board](https://miro.com/app/board/uXjVPSu6wlI=/)

[Upstream Issue](https://github.com/mozilla/cargo-vet/issues/330)

Most of this is just a bunch of churn to make the json schema more explicitly typed so that other things can more easily consume it.

TODO:

* [x] Change cargo-vet to be bottable
  * [x] emit extra context in the json output
  * [x] ? add a --with-metadata flag to be able to pass a cached cargo-metadata on stdin(?)/file(?) to operate "headless"
* [x] create a Github App/Action that runs `cargo vet --output-format=json-full`
  * [x] have the bot send the json blob to our webapp and get back some kind of transcation id
  * [x] have the bot post a comment on the repo with the issue / link to webapp with that id
  * [x] have the bot(?) able to run `cargo-vet certify` in CI at the webapp's request?
* [x] create a webapp
  * [x] have a simple database (redis?)
  * [x] render the json report
  * [x] have a form for the values in `certify`
  * [x] have the webapp auth the user with github to be able to do things on their behalf
  * [x] have the webapp command the bot(?) to do a certify on submit